### PR TITLE
feat: rename game currency to population

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -4,9 +4,9 @@ import { HUD } from './components/HUD';
 import { useGameStore } from './app/store';
 
 describe('HUD', () => {
-  it('increments coins on click', () => {
+  it('increments population on click', () => {
     render(<HUD />);
     fireEvent.click(screen.getByText(/click/i));
-    expect(useGameStore.getState().coins).toBe(1);
+    expect(useGameStore.getState().population).toBe(1);
   });
 });

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -3,10 +3,10 @@ import { persist } from 'zustand/middleware';
 import balance from '../lib/balance';
 
 interface State {
-  coins: number;
+  population: number;
   generators: Record<string, number>;
   lastSaved: number;
-  addCoins: (amount: number) => void;
+  addPopulation: (amount: number) => void;
   buyGenerator: (id: string) => void;
   tick: (delta: number) => void;
 }
@@ -14,18 +14,19 @@ interface State {
 export const useGameStore = create<State>()(
   persist(
     (set, get) => ({
-      coins: 0,
+      population: 0,
       generators: {},
       lastSaved: Date.now(),
-      addCoins: (amount) => set((s) => ({ coins: s.coins + amount })),
+      addPopulation: (amount) =>
+        set((s) => ({ population: s.population + amount })),
       buyGenerator: (id) => {
         const gen = balance.generators.find((g) => g.id === id);
         if (!gen) return;
         const count = get().generators[id] || 0;
         const price = balance.getPrice(gen, count);
-        if (get().coins >= price) {
+        if (get().population >= price) {
           set((s) => ({
-            coins: s.coins - price,
+            population: s.population - price,
             generators: { ...s.generators, [id]: count + 1 },
           }));
         }
@@ -37,7 +38,7 @@ export const useGameStore = create<State>()(
           const count = s.generators[gen.id] || 0;
           gain += gen.rate * count * delta;
         }
-        if (gain > 0) set({ coins: s.coins + gain });
+        if (gain > 0) set({ population: s.population + gain });
       },
     }),
     {
@@ -51,7 +52,7 @@ export const useGameStore = create<State>()(
             const count = state.generators[gen.id] || 0;
             gain += gen.rate * count * delta;
           }
-          state.coins += gain;
+          state.population += gain;
           state.lastSaved = now;
         }
       },

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -1,12 +1,12 @@
 import { useGameStore } from '../app/store';
 
 export function HUD() {
-  const coins = useGameStore((s) => s.coins);
-  const addCoins = useGameStore((s) => s.addCoins);
+  const population = useGameStore((s) => s.population);
+  const addPopulation = useGameStore((s) => s.addPopulation);
   return (
     <div>
-      <div>Coins: {Math.floor(coins)}</div>
-      <button onClick={() => addCoins(1)}>Click</button>
+      <div>Population: {Math.floor(population)}</div>
+      <button onClick={() => addPopulation(1)}>Click</button>
     </div>
   );
 }

--- a/src/components/Store.tsx
+++ b/src/components/Store.tsx
@@ -3,7 +3,7 @@ import balance from '../lib/balance';
 
 export function Store() {
   const buy = useGameStore((s) => s.buyGenerator);
-  const coins = useGameStore((s) => s.coins);
+  const population = useGameStore((s) => s.population);
   const generators = useGameStore((s) => s.generators);
   return (
     <div>
@@ -14,7 +14,7 @@ export function Store() {
         return (
           <div key={gen.id}>
             <span>{gen.name} ({count}) </span>
-            <button disabled={coins < price} onClick={() => buy(gen.id)}>
+            <button disabled={population < price} onClick={() => buy(gen.id)}>
               Buy {Math.round(price)}
             </button>
           </div>

--- a/src/lib/balance.ts
+++ b/src/lib/balance.ts
@@ -3,7 +3,7 @@ export interface Generator {
   name: string;
   baseCost: number;
   costMultiplier: number;
-  rate: number; // coins per second
+  rate: number; // population per second
 }
 
 export const balance = {


### PR DESCRIPTION
## Summary
- rename store state from coins to population
- update HUD and store components to display population
- adjust tests and balance comments for population-based currency

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c05865898c8328a793f26f8111f1f9