### PR TITLE
feat: upgrades

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { HUD } from './components/HUD';
 import { Store } from './components/Store';
+import { Upgrades } from './components/Upgrades';
 import { startGameLoop } from './app/gameLoop';
 import './App.css';
 
@@ -12,6 +13,7 @@ function App() {
     <>
       <HUD />
       <Store />
+      <Upgrades />
     </>
   );
 }

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,13 +1,19 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import balance from '../lib/balance';
+import upgrades from '../lib/upgrades';
 
 interface State {
   population: number;
   generators: Record<string, number>;
+  upgrades: Set<string>;
+  clickPower: number;
+  cpsMultiplier: number;
   lastSaved: number;
   addPopulation: (amount: number) => void;
   buyGenerator: (id: string) => void;
+  purchaseUpgrade: (id: string) => void;
+  recompute: () => void;
   tick: (delta: number) => void;
 }
 
@@ -16,6 +22,9 @@ export const useGameStore = create<State>()(
     (set, get) => ({
       population: 0,
       generators: {},
+      upgrades: new Set<string>(),
+      clickPower: 1,
+      cpsMultiplier: 1,
       lastSaved: Date.now(),
       addPopulation: (amount) =>
         set((s) => ({ population: s.population + amount })),
@@ -31,18 +40,63 @@ export const useGameStore = create<State>()(
           }));
         }
       },
+      purchaseUpgrade: (id) => {
+        const upg = upgrades.find((u) => u.id === id);
+        const s = get();
+        if (!upg || s.upgrades.has(id) || s.population < upg.cost) return;
+        const owned = new Set(s.upgrades);
+        owned.add(id);
+        set({ population: s.population - upg.cost, upgrades: owned });
+        get().recompute();
+      },
+      recompute: () => {
+        const owned = get().upgrades;
+        let click = 1;
+        let cps = 1;
+        for (const id of owned) {
+          const upg = upgrades.find((u) => u.id === id);
+          if (!upg) continue;
+          const { type, target, value } = upg.apply;
+          if (target === 'click') {
+            if (type === 'add') click += value;
+            else click *= value;
+          } else if (target === 'cps') {
+            if (type === 'add') cps += value;
+            else cps *= value;
+          }
+        }
+        set({ clickPower: click, cpsMultiplier: cps });
+      },
       tick: (delta) => {
         const s = get();
         let gain = 0;
         for (const gen of balance.generators) {
           const count = s.generators[gen.id] || 0;
-          gain += gen.rate * count * delta;
+          gain += gen.rate * count * delta * s.cpsMultiplier;
         }
         if (gain > 0) set({ population: s.population + gain });
       },
     }),
     {
       name: 'suomidle',
+      serialize: (state) =>
+        JSON.stringify({
+          ...state,
+          state: {
+            ...state.state,
+            upgrades: Array.from(state.state.upgrades as Set<string>),
+          },
+        }),
+      deserialize: (str) => {
+        const data = JSON.parse(str);
+        return {
+          ...data,
+          state: {
+            ...data.state,
+            upgrades: new Set<string>(data.state.upgrades),
+          },
+        };
+      },
       onRehydrateStorage: () => (state) => {
         if (state) {
           const now = Date.now();
@@ -50,10 +104,11 @@ export const useGameStore = create<State>()(
           let gain = 0;
           for (const gen of balance.generators) {
             const count = state.generators[gen.id] || 0;
-            gain += gen.rate * count * delta;
+            gain += gen.rate * count * delta * state.cpsMultiplier;
           }
           state.population += gain;
           state.lastSaved = now;
+          state.recompute();
         }
       },
     }

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -3,10 +3,11 @@ import { useGameStore } from '../app/store';
 export function HUD() {
   const population = useGameStore((s) => s.population);
   const addPopulation = useGameStore((s) => s.addPopulation);
+  const click = useGameStore((s) => s.clickPower);
   return (
     <div>
       <div>Population: {Math.floor(population)}</div>
-      <button onClick={() => addPopulation(1)}>Click</button>
+      <button onClick={() => addPopulation(click)}>Click</button>
     </div>
   );
 }

--- a/src/components/Upgrades.tsx
+++ b/src/components/Upgrades.tsx
@@ -1,0 +1,26 @@
+import { useGameStore } from '../app/store';
+import upgrades from '../lib/upgrades';
+
+export function Upgrades() {
+  const population = useGameStore((s) => s.population);
+  const owned = useGameStore((s) => s.upgrades);
+  const buy = useGameStore((s) => s.purchaseUpgrade);
+  return (
+    <div>
+      <h2>Upgrades</h2>
+      {upgrades.map((u) => (
+        <div key={u.id}>
+          <span>
+            {u.name} ({u.cost})
+          </span>
+          <button
+            disabled={population < u.cost || owned.has(u.id)}
+            onClick={() => buy(u.id)}
+          >
+            Buy
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/upgrades.ts
+++ b/src/lib/upgrades.ts
@@ -1,0 +1,33 @@
+export interface UpgradeDef {
+  id: string;
+  name: string;
+  cost: number;
+  apply: {
+    type: 'add' | 'mult';
+    target: 'click' | 'cps';
+    value: number;
+  };
+}
+
+export const upgrades: UpgradeDef[] = [
+  {
+    id: 'plus1',
+    name: 'Plus One',
+    cost: 10,
+    apply: { type: 'add', target: 'click', value: 1 },
+  },
+  {
+    id: 'double',
+    name: 'Double Click',
+    cost: 25,
+    apply: { type: 'mult', target: 'click', value: 2 },
+  },
+  {
+    id: 'triple',
+    name: 'Triple Click',
+    cost: 50,
+    apply: { type: 'mult', target: 'click', value: 3 },
+  },
+];
+
+export default upgrades;

--- a/src/upgrades.test.ts
+++ b/src/upgrades.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useGameStore } from './app/store';
+
+describe('upgrades', () => {
+  beforeEach(() => {
+    useGameStore.persist.clearStorage();
+    useGameStore.setState({
+      population: 0,
+      generators: {},
+      upgrades: new Set<string>(),
+      clickPower: 1,
+      cpsMultiplier: 1,
+      lastSaved: Date.now(),
+    });
+  });
+
+  it('mult stacks multiplicatively', () => {
+    useGameStore.setState({ population: 1000 });
+    const purchase = useGameStore.getState().purchaseUpgrade;
+    purchase('double');
+    purchase('triple');
+    expect(useGameStore.getState().clickPower).toBe(6);
+  });
+
+  it('add increases click', () => {
+    useGameStore.setState({ population: 10 });
+    useGameStore.getState().purchaseUpgrade('plus1');
+    useGameStore.getState().addPopulation(useGameStore.getState().clickPower);
+    expect(useGameStore.getState().population).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- introduce upgrade definitions for click and cps bonuses
- support purchasing and applying upgrades in the game store
- add upgrades UI with buy buttons and new tests

## Testing
- `npm test`

Closes #<issue>

cc @me @co-creator

------
https://chatgpt.com/codex/tasks/task_e_68c063eb11c88328b61a71ff20574026