### PR TITLE
Apply multiplier to passive gain calculations

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -79,8 +79,9 @@ export const useGameStore = create<State>()(
         let gain = 0;
         for (const gen of balance.generators) {
           const count = s.generators[gen.id] || 0;
-          gain += gen.rate * count * delta * s.cpsMultiplier * s.multiplier;
+          gain += gen.rate * count * delta * s.cpsMultiplier;
         }
+        gain *= s.multiplier;
         if (gain > 0) set({ population: s.population + gain });
       },
       prestige: () => {
@@ -125,9 +126,9 @@ export const useGameStore = create<State>()(
           let gain = 0;
           for (const gen of balance.generators) {
             const count = state.generators[gen.id] || 0;
-            gain +=
-              gen.rate * count * delta * state.cpsMultiplier * state.multiplier;
+            gain += gen.rate * count * delta * state.cpsMultiplier;
           }
+          gain *= state.multiplier;
           state.population += gain;
           state.lastSaved = now;
           state.recompute();


### PR DESCRIPTION
## Summary
- scale passive population gain in `tick` with current multiplier
- apply multiplier to offline population gain on rehydration

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0680d25dc832897185d122ddb459a