### PR TITLE
Add prestige config gating prestige action

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -2,8 +2,16 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import balance from '../lib/balance';
 import upgrades from '../lib/upgrades';
+import prestigeData from '../lib/prestige.json' assert { type: 'json' };
 
-const baseMultiplier = 2;
+export interface PrestigeConfig {
+  threshold: number;
+  baseMultiplier: number;
+  [key: string]: unknown;
+}
+
+export const prestigeConfig: PrestigeConfig = prestigeData as PrestigeConfig;
+const baseMultiplier = prestigeConfig.baseMultiplier;
 
 interface State {
   population: number;
@@ -84,6 +92,7 @@ export const useGameStore = create<State>()(
         if (gain > 0) set({ population: s.population + gain });
       },
       prestige: () => {
+        if (get().population < prestigeConfig.threshold) return;
         set((s) => {
           const level = s.prestigeLevel + 1;
           const mult = baseMultiplier ** level;

--- a/src/lib/prestige.json
+++ b/src/lib/prestige.json
@@ -1,0 +1,5 @@
+{
+  "threshold": 1000,
+  "baseMultiplier": 2,
+  "rewards": {}
+}


### PR DESCRIPTION
## Summary
- add JSON config for prestige thresholds and base multiplier
- load prestige config in store with `PrestigeConfig` interface
- gate prestige resets behind configurable population threshold

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0681cf1cc83288b1ce33a03e15fe0