### PR TITLE
Add Prestige component for reset mechanic

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { HUD } from './components/HUD';
 import { Store } from './components/Store';
+import { Prestige } from './components/Prestige';
 import { Upgrades } from './components/Upgrades';
 import { startGameLoop } from './app/gameLoop';
 import './App.css';
@@ -13,6 +14,7 @@ function App() {
     <>
       <HUD />
       <Store />
+      <Prestige />
       <Upgrades />
     </>
   );

--- a/src/components/Prestige.tsx
+++ b/src/components/Prestige.tsx
@@ -1,0 +1,22 @@
+import { useGameStore } from '../app/store';
+import balance from '../lib/balance';
+
+export function Prestige() {
+  const population = useGameStore((s) => s.population);
+  const prestige = useGameStore((s) => s.prestige);
+  const level = useGameStore((s) => s.prestigeLevel);
+  const multiplier = useGameStore((s) => s.multiplier);
+  return (
+    <div>
+      <h2>Prestige</h2>
+      <div>Prestige Level: {level}</div>
+      <div>Multiplier: {multiplier}x</div>
+      <button
+        disabled={population < balance.prestigeThreshold}
+        onClick={() => prestige()}
+      >
+        Prestige
+      </button>
+    </div>
+  );
+}

--- a/src/lib/balance.ts
+++ b/src/lib/balance.ts
@@ -14,6 +14,7 @@ export const balance = {
   getPrice(gen: Generator, count: number) {
     return gen.baseCost * Math.pow(gen.costMultiplier, count);
   },
+  prestigeThreshold: 1_000_000,
 };
 
 export default balance;


### PR DESCRIPTION
## Summary
- add Prestige component with prestige level, multiplier and reset button
- expose prestige threshold in balance configuration
- render Prestige component in main app

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0681e82848328b876dbbbbcd2523a