### PR TITLE
chore: remove unused serialization helpers

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -19,12 +19,6 @@ export interface PrestigeConfig {
 export const prestigeConfig: PrestigeConfig = prestigeData as PrestigeConfig;
 const baseMultiplier = prestigeConfig.baseMultiplier;
 
-const replacer = (_key: string, value: unknown) =>
-  value instanceof Set ? Array.from(value) : value;
-
-const reviver = (key: string, value: unknown) =>
-  key === 'upgrades' && Array.isArray(value) ? new Set(value) : value;
-
 interface State {
   population: number;
   generators: Record<string, number>;


### PR DESCRIPTION
## Summary
- remove unused replacer and reviver functions from store

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c07402207883288b97b1cf40f5ecd0