### PR TITLE
Add data-first content definitions for buildings, tech, and tiers

### DIFF
--- a/src/content/buildings.json
+++ b/src/content/buildings.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "sauna",
+    "name": "Sauna",
+    "icon": "Sauna.png",
+    "baseCost": 10,
+    "costMult": 1.15,
+    "baseProd": 0.1
+  },
+  {
+    "id": "kylakauppa",
+    "name": "Kyläkauppa",
+    "icon": "Kyläkauppa.png",
+    "baseCost": 100,
+    "costMult": 1.15,
+    "baseProd": 1
+  },
+  {
+    "id": "alko",
+    "name": "Alko",
+    "icon": "Alko.png",
+    "baseCost": 1000,
+    "costMult": 1.15,
+    "baseProd": 6
+  },
+  {
+    "id": "ensiapu",
+    "name": "Ensiapu",
+    "icon": "Ensiapu.png",
+    "baseCost": 5000,
+    "costMult": 1.16,
+    "baseProd": 20,
+    "unlock": { "tier": 2 }
+  }
+]

--- a/src/content/tech.json
+++ b/src/content/tech.json
@@ -1,0 +1,31 @@
+[
+  {
+    "id": "vihta",
+    "name": "Vihta",
+    "icon": "Vihta.png",
+    "cost": 500,
+    "effects": [
+      { "type": "mult", "target": "population_cps", "value": 1.25 }
+    ]
+  },
+  {
+    "id": "kalja",
+    "name": "Kalja",
+    "icon": "Kalja.png",
+    "cost": 3000,
+    "effects": [
+      { "type": "mult", "target": "population_cps", "value": 1.5 }
+    ],
+    "unlock": { "tier": 2 }
+  },
+  {
+    "id": "kossu",
+    "name": "Kossu",
+    "icon": "Kossu.png",
+    "cost": 10000,
+    "effects": [
+      { "type": "mult", "target": "population_cps", "value": 1.6 }
+    ],
+    "unlock": { "tier": 3 }
+  }
+]

--- a/src/content/tiers.json
+++ b/src/content/tiers.json
@@ -1,0 +1,6 @@
+[
+  { "tier": 1, "name": "Sauna", "population": 0 },
+  { "tier": 2, "name": "Savusauna", "population": 2000 },
+  { "tier": 3, "name": "Suur-sauna", "population": 40000 },
+  { "tier": 4, "name": "Nation", "population": 1000000 }
+]

--- a/src/content/types.ts
+++ b/src/content/types.ts
@@ -1,0 +1,40 @@
+export interface Resource {
+  id: string;
+  name: string;
+  icon?: string;
+}
+
+export interface BuildingDef {
+  id: string;
+  name: string;
+  icon: string;
+  baseCost: number;
+  costMult: number;
+  baseProd: number;
+  unlock?: {
+    tier: number;
+  };
+}
+
+export interface TechEffect {
+  type: 'mult' | 'add';
+  target: string;
+  value: number;
+}
+
+export interface TechDef {
+  id: string;
+  name: string;
+  icon: string;
+  cost: number;
+  effects: TechEffect[];
+  unlock?: {
+    tier: number;
+  };
+}
+
+export interface TierDef {
+  name: string;
+  tier: number;
+  population: number;
+}


### PR DESCRIPTION
## Summary
- define reusable Resource, Building, Tech, and Tier TypeScript interfaces
- add starter building data for Sauna, Kyläkauppa, Alko, and Ensiapu
- include technology entries Vihta, Kalja, and Kossu
- outline tier progression from Sauna to Nation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0762b13808328b8a5f5f17c7ad8a7