### PR TITLE
Use BASE_URL for asset icons

### DIFF
--- a/src/components/BuildingsGrid.tsx
+++ b/src/components/BuildingsGrid.tsx
@@ -20,7 +20,7 @@ export function BuildingsGrid() {
         return (
           <ImageCardButton
             key={b.id}
-            icon={`/assets/buildings/${b.icon}`}
+            icon={`${import.meta.env.BASE_URL}assets/buildings/${b.icon}`}
             title={`${b.name} (${count})`}
             subtitle={`Next: ${Math.round(price)} | +${cpsDelta.toFixed(2)} CPS`}
             disabled={disabled}

--- a/src/components/TechGrid.tsx
+++ b/src/components/TechGrid.tsx
@@ -20,7 +20,7 @@ export function TechGrid() {
         return (
           <ImageCardButton
             key={t.id}
-            icon={`/assets/tech/${t.icon}`}
+            icon={`${import.meta.env.BASE_URL}assets/tech/${t.icon}`}
             title={t.name}
             subtitle={subtitle}
             disabled={disabled}


### PR DESCRIPTION
## Summary
- Resolve icon URLs using `import.meta.env.BASE_URL` for buildings and tech grids

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `curl -I http://localhost:4174/Suomidle/`
- `curl -I http://localhost:4174/Suomidle/assets/buildings/Alko.png`


------
https://chatgpt.com/codex/tasks/task_e_68c09b8550208328a13ad0aa6d91152b