### PR TITLE
Track technology purchase counts and reset old saves

### DIFF
--- a/src/components/TechGrid.tsx
+++ b/src/components/TechGrid.tsx
@@ -5,13 +5,15 @@ import { ImageCardButton } from './ImageCardButton';
 export function TechGrid() {
   const population = useGameStore((s) => s.population);
   const tier = useGameStore((s) => s.tierLevel);
-  const owned = useGameStore((s) => s.techOwned);
+  const counts = useGameStore((s) => s.techCounts);
   const buy = useGameStore((s) => s.purchaseTech);
 
   return (
     <div style={{ display: 'flex', flexWrap: 'wrap' }}>
       {tech.map((t) => {
-        const isOwned = owned.has(t.id);
+        const count = counts[t.id] || 0;
+        const limit = t.limit ?? 1;
+        const isOwned = count >= limit;
         const locked = !!(t.unlock?.tier && tier < t.unlock.tier);
         const disabled = isOwned || locked || population < t.cost;
         const subtitle = `${isOwned ? 'Owned' : locked ? 'Locked' : ''}${

--- a/src/components/Upgrades.tsx
+++ b/src/components/Upgrades.tsx
@@ -3,7 +3,7 @@ import { tech as techList } from '../content';
 
 export function Upgrades() {
   const population = useGameStore((s) => s.population);
-  const owned = useGameStore((s) => s.techOwned);
+  const counts = useGameStore((s) => s.techCounts);
   const buy = useGameStore((s) => s.purchaseTech);
   const tier = useGameStore((s) => s.tierLevel);
   return (
@@ -17,7 +17,9 @@ export function Upgrades() {
               {t.name} ({t.cost})
             </span>
             <button
-              disabled={population < t.cost || owned.has(t.id)}
+              disabled={
+                population < t.cost || (counts[t.id] || 0) >= (t.limit ?? 1)
+              }
               onClick={() => buy(t.id)}
             >
               Buy

--- a/src/content/tech.json
+++ b/src/content/tech.json
@@ -6,7 +6,8 @@
     "cost": 500,
     "effects": [
       { "type": "mult", "target": "population_cps", "value": 1.25 }
-    ]
+    ],
+    "limit": 1
   },
   {
     "id": "kalja",
@@ -16,6 +17,7 @@
     "effects": [
       { "type": "mult", "target": "population_cps", "value": 1.5 }
     ],
+    "limit": 1,
     "unlock": { "tier": 2 }
   },
   {
@@ -26,6 +28,7 @@
     "effects": [
       { "type": "mult", "target": "population_cps", "value": 1.6 }
     ],
+    "limit": 1,
     "unlock": { "tier": 3 }
   },
   {
@@ -36,6 +39,7 @@
     "effects": [
       { "type": "mult", "target": "population_cps", "value": 1.30 }
     ],
+    "limit": 1,
     "unlock": { "tier": 4 }
   },
   {
@@ -46,6 +50,7 @@
     "effects": [
       { "type": "mult", "target": "population_cps", "value": 1.40 }
     ],
+    "limit": 1,
     "unlock": { "tier": 5 }
   },
   {
@@ -56,6 +61,7 @@
     "effects": [
       { "type": "mult", "target": "population_cps", "value": 1.50 }
     ],
+    "limit": 1,
     "unlock": { "tier": 6 }
   },
   {
@@ -66,6 +72,7 @@
     "effects": [
       { "type": "mult", "target": "population_cps", "value": 1.70 }
     ],
+    "limit": 1,
     "unlock": { "tier": 7 }
   }
 ]

--- a/src/content/types.ts
+++ b/src/content/types.ts
@@ -28,6 +28,7 @@ export interface TechDef {
   icon: string;
   cost: number;
   effects: TechEffect[];
+  limit?: number;
   unlock?: {
     tier: number;
   };

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useGameStore } from './app/store';
 
-describe('model v2', () => {
+describe('model v3', () => {
   beforeEach(() => {
     useGameStore.persist.clearStorage();
     useGameStore.setState({
       population: 0,
       tierLevel: 1,
       buildings: {},
-      techOwned: new Set<string>(),
+      techCounts: {},
       multipliers: { population_cps: 1 },
       cps: 0,
       clickPower: 1,
@@ -31,14 +31,35 @@ describe('model v2', () => {
     expect(useGameStore.getState().cps).toBeCloseTo(before * 1.25);
   });
 
-  it('rehydrates techOwned from stored array', async () => {
+  it('rehydrates techCounts from stored object', async () => {
     const payload = {
       state: {
         population: 0,
         tierLevel: 1,
         buildings: {},
-        techOwned: ['vihta'],
+        techCounts: { vihta: 1 },
         multipliers: { population_cps: 1 },
+        cps: 0,
+        clickPower: 1,
+      },
+      version: 3,
+    };
+    localStorage.setItem('suomidle', JSON.stringify(payload));
+    await useGameStore.persist.rehydrate();
+    const counts = useGameStore.getState().techCounts;
+    expect(counts.vihta).toBe(1);
+    useGameStore.getState().purchaseTech('vihta');
+    expect(useGameStore.getState().techCounts.vihta).toBe(1);
+  });
+
+  it('migrates v2 saves without resetting if no duplicate tech purchases', async () => {
+    const payload = {
+      state: {
+        population: 50,
+        tierLevel: 1,
+        buildings: { sauna: 1 },
+        techOwned: ['vihta'],
+        multipliers: { population_cps: 10 },
         cps: 0,
         clickPower: 1,
       },
@@ -46,8 +67,33 @@ describe('model v2', () => {
     };
     localStorage.setItem('suomidle', JSON.stringify(payload));
     await useGameStore.persist.rehydrate();
-    const owned = useGameStore.getState().techOwned;
-    expect(owned instanceof Set).toBe(true);
-    expect(owned.has('vihta')).toBe(true);
+    const state = useGameStore.getState();
+    expect(state.population).toBe(50);
+    expect(state.buildings.sauna).toBe(1);
+    expect(state.techCounts.vihta).toBe(1);
+    expect(state.multipliers.population_cps).toBeCloseTo(1.25);
+    expect(state.cps).toBeCloseTo(0.125);
+  });
+
+  it('resets save if migrated techCounts contain duplicates', async () => {
+    const payload = {
+      state: {
+        population: 100,
+        tierLevel: 2,
+        buildings: { sauna: 2 },
+        techCounts: { vihta: 2 },
+        multipliers: { population_cps: 5 },
+        cps: 0,
+        clickPower: 1,
+      },
+      version: 2,
+    };
+    localStorage.setItem('suomidle', JSON.stringify(payload));
+    await useGameStore.persist.rehydrate();
+    const state = useGameStore.getState();
+    expect(state.population).toBe(0);
+    expect(state.buildings.sauna).toBeUndefined();
+    expect(state.techCounts.vihta).toBeUndefined();
+    expect(state.tierLevel).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- Track technology purchases with counts and enforce per-tech limits (default 1)
- Reset old save data only if duplicate tech purchases are detected and recompute multipliers
- Update UI and tests for new tech purchase logic

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c154e1a0b08328b0b1bfe7f797d1e2