### PR TITLE
feat: prestige — Polta sauna (schema v3, data-first)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@ npm run build # create production build
 - Prestige/reset system
 - Achievements and statistics
 
+## Prestige (Polta sauna)
+
+Reset your population, buildings, technologies and tier level for a permanent population-per-second multiplier.  Prestige points follow a square-root curve based on lifetime population:
+
+```
+points = floor( sqrt(totalPopulation / 100000) )
+multiplier = 1 + points * 0.10
+```
+
+The prestige button unlocks at 10 000 total population and displays your current multiplier and projected gain.
+
 ## License
 
 MIT

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { HUD } from './components/HUD';
 import { BuildingsGrid } from './components/BuildingsGrid';
 import { TechGrid } from './components/TechGrid';
 import { Prestige } from './components/Prestige';
+import { PrestigeCard } from './components/PrestigeCard';
 import { startGameLoop } from './app/gameLoop';
 import './App.css';
 
@@ -13,6 +14,7 @@ function App() {
   return (
     <>
       <HUD />
+      <PrestigeCard />
       <BuildingsGrid />
       <TechGrid />
       <Prestige />

--- a/src/components/PrestigeCard.tsx
+++ b/src/components/PrestigeCard.tsx
@@ -1,0 +1,27 @@
+import { ImageCardButton } from './ImageCardButton';
+import { useGameStore } from '../app/store';
+import { prestige as prestigeData } from '../content';
+
+export function PrestigeCard() {
+  const mult = useGameStore((s) => s.prestigeMult);
+  const canPrestige = useGameStore((s) => s.canPrestige());
+  const { multAfter, deltaMult } = useGameStore((s) => s.projectPrestigeGain());
+  const prestige = useGameStore((s) => s.prestige);
+
+  const subtitle = canPrestige
+    ? `Gain +${(deltaMult * 100).toFixed(0)}% → ${multAfter.toFixed(2)}×`
+    : `Unlock at ${prestigeData.minPopulation} population`;
+
+  return (
+    <ImageCardButton
+      icon={prestigeData.icon}
+      title={`Prestige: ${mult.toFixed(2)}×`}
+      subtitle={subtitle}
+      disabled={!canPrestige}
+      onClick={() => {
+        if (!canPrestige) return;
+        if (confirm('Reset progress and gain prestige multiplier?')) prestige();
+      }}
+    />
+  );
+}

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,11 +1,13 @@
 import buildingsData from './buildings.json' assert { type: 'json' };
 import techData from './tech.json' assert { type: 'json' };
 import tiersData from './tiers.json' assert { type: 'json' };
-import type { BuildingDef, TechDef, TierDef } from './types';
+import prestigeData from './prestige.json' assert { type: 'json' };
+import type { BuildingDef, TechDef, TierDef, PrestigeDef } from './types';
 
 export const buildings = buildingsData as BuildingDef[];
 export const tech = techData as TechDef[];
 export const tiers = tiersData as TierDef[];
+export const prestige = prestigeData as PrestigeDef;
 
 export const getBuilding = (id: string) => buildings.find((b) => b.id === id);
 export const getTech = (id: string) => tech.find((t) => t.id === id);

--- a/src/content/prestige.json
+++ b/src/content/prestige.json
@@ -1,0 +1,13 @@
+{
+  "id": "polta_sauna",
+  "name": "Polta sauna",
+  "icon": "/assets/ui/torch.png",
+  "minPopulation": 10000,
+  "formula": {
+    "type": "sqrt",
+    "k": 100000,
+    "multPerPoint": 0.10,
+    "base": 1.0,
+    "stacking": "add"
+  }
+}

--- a/src/content/types.ts
+++ b/src/content/types.ts
@@ -39,3 +39,19 @@ export interface TierDef {
   tier: number;
   population: number;
 }
+
+export interface PrestigeFormula {
+  type: 'sqrt';
+  k: number;
+  multPerPoint: number;
+  base: number;
+  stacking: 'add';
+}
+
+export interface PrestigeDef {
+  id: string;
+  name: string;
+  icon: string;
+  minPopulation: number;
+  formula: PrestigeFormula;
+}

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -6,12 +6,15 @@ describe('model v3', () => {
     useGameStore.persist.clearStorage();
     useGameStore.setState({
       population: 0,
+      totalPopulation: 0,
       tierLevel: 1,
       buildings: {},
       techCounts: {},
       multipliers: { population_cps: 1 },
       cps: 0,
       clickPower: 1,
+      prestigePoints: 0,
+      prestigeMult: 1,
     });
     useGameStore.getState().recompute();
   });

--- a/src/tests/prestige.test.ts
+++ b/src/tests/prestige.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useGameStore, computePrestigePoints, computePrestigeMult } from '../app/store';
+
+describe('prestige', () => {
+  beforeEach(() => {
+    useGameStore.persist.clearStorage();
+    useGameStore.setState({
+      population: 0,
+      totalPopulation: 0,
+      tierLevel: 1,
+      buildings: {},
+      techCounts: {},
+      multipliers: { population_cps: 1 },
+      cps: 0,
+      clickPower: 1,
+      prestigePoints: 0,
+      prestigeMult: 1,
+    });
+    useGameStore.getState().recompute();
+  });
+
+  it('cannot prestige below minimum population', () => {
+    useGameStore.setState({ totalPopulation: 9999 });
+    expect(useGameStore.getState().canPrestige()).toBe(false);
+  });
+
+  it('computes points and multiplier at 100k population', () => {
+    expect(computePrestigePoints(100000)).toBe(1);
+    expect(computePrestigeMult(1)).toBeCloseTo(1.1);
+  });
+
+  it('prestige resets progress and keeps lifetime stats', () => {
+    useGameStore.setState({
+      population: 500,
+      totalPopulation: 100000,
+      buildings: { sauna: 2 },
+      techCounts: { vihta: 1 },
+      tierLevel: 2,
+      multipliers: { population_cps: 1.25 },
+      cps: 10,
+      prestigePoints: 0,
+      prestigeMult: 1,
+    });
+    const ok = useGameStore.getState().prestige();
+    const s = useGameStore.getState();
+    expect(ok).toBe(true);
+    expect(s.population).toBe(0);
+    expect(s.buildings.sauna).toBeUndefined();
+    expect(Object.keys(s.techCounts).length).toBe(0);
+    expect(s.tierLevel).toBe(1);
+    expect(s.totalPopulation).toBe(100000);
+    expect(s.prestigePoints).toBe(1);
+    expect(s.prestigeMult).toBeCloseTo(1.1);
+  });
+});


### PR DESCRIPTION
## Summary
- add data-driven prestige definition and supporting store logic
- wire prestige multiplier into CPS and expose Polta sauna UI card
- document prestige formula and add tests

## Testing
- `npm test`

cc @me @co-creator

------
https://chatgpt.com/codex/tasks/task_e_68c15b8946c48328b6e9bc7c51b47079