### PR TITLE
Initialize cps after mount

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,11 +5,13 @@ import { TechGrid } from './components/TechGrid';
 import { Prestige } from './components/Prestige';
 import { PrestigeCard } from './components/PrestigeCard';
 import { startGameLoop } from './app/gameLoop';
+import { useGameStore } from './app/store';
 import './App.css';
 
 function App() {
   useEffect(() => {
     startGameLoop();
+    useGameStore.getState().recompute();
   }, []);
   return (
     <>

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -248,11 +248,7 @@ export const useGameStore = create<State>()(
           prestigeMult: 1,
         };
       },
-      onRehydrateStorage: () => (state: State | undefined) => {
-        if (state) {
-          state.recompute();
-        }
-      },
+      onRehydrateStorage: () => () => {},
     } as PersistOptions<State, Partial<State>>,
   ),
 );
@@ -267,9 +263,9 @@ export const saveGame = () => {
   delete rest.tick;
   delete rest.canAdvanceTier;
   delete rest.advanceTier;
-  delete (rest as any).canPrestige;
-  delete (rest as any).projectPrestigeGain;
-  delete (rest as any).prestige;
+  delete rest.canPrestige;
+  delete rest.projectPrestigeGain;
+  delete rest.prestige;
   const data = { state: rest, version: 3 };
   localStorage.setItem('suomidle', JSON.stringify(data));
 };

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -70,6 +70,7 @@ describe('model v3', () => {
     };
     localStorage.setItem('suomidle', JSON.stringify(payload));
     await useGameStore.persist.rehydrate();
+    useGameStore.getState().recompute();
     const state = useGameStore.getState();
     expect(state.population).toBe(50);
     expect(state.buildings.sauna).toBe(1);


### PR DESCRIPTION
## Summary
- Remove onRehydrateStorage recompute to avoid repeated state updates
- Initialize cps once on mount via `useEffect`
- Adjust store tests for explicit recompute after rehydration

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c15fd2043c832881f12fd639ca6a72