### PR TITLE
fix CPS initialization after hydration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,8 @@ import './App.css';
 function App() {
   useEffect(() => {
     startGameLoop();
+  }, []);
+  useEffect(() => {
     useGameStore.getState().recompute();
   }, []);
   return (

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -248,7 +248,7 @@ export const useGameStore = create<State>()(
           prestigeMult: 1,
         };
       },
-      onRehydrateStorage: () => () => {},
+      onRehydrateStorage: () => undefined,
     } as PersistOptions<State, Partial<State>>,
   ),
 );


### PR DESCRIPTION
## Summary
- Remove redundant `onRehydrateStorage` callback
- Recompute CPS after `App` mounts to initialize state

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c16257dbc88328b49654996af000c9