### PR TITLE
Add game loop stop control and cleanup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,13 +4,16 @@ import { BuildingsGrid } from './components/BuildingsGrid';
 import { TechGrid } from './components/TechGrid';
 import { Prestige } from './components/Prestige';
 import { PrestigeCard } from './components/PrestigeCard';
-import { startGameLoop } from './app/gameLoop';
+import { startGameLoop, stopGameLoop } from './app/gameLoop';
 import { useGameStore } from './app/store';
 import './App.css';
 
 function App() {
   useEffect(() => {
     startGameLoop();
+    return () => {
+      stopGameLoop();
+    };
   }, []);
   useEffect(() => {
     useGameStore.getState().recompute();

--- a/src/app/gameLoop.ts
+++ b/src/app/gameLoop.ts
@@ -1,9 +1,13 @@
 import { useGameStore, saveGame } from './store';
 
-let last = performance.now();
+let last = 0;
 let sinceSave = 0;
+let frameId: number | null = null;
 
 export function startGameLoop() {
+  last = performance.now();
+  sinceSave = 0;
+
   function frame(now: number) {
     const delta = (now - last) / 1000;
     last = now;
@@ -13,7 +17,16 @@ export function startGameLoop() {
       saveGame();
       sinceSave = 0;
     }
-    requestAnimationFrame(frame);
+    frameId = requestAnimationFrame(frame);
   }
-  requestAnimationFrame(frame);
+
+  frameId = requestAnimationFrame(frame);
+  return frameId;
+}
+
+export function stopGameLoop() {
+  if (frameId !== null) {
+    cancelAnimationFrame(frameId);
+    frameId = null;
+  }
 }


### PR DESCRIPTION
## Summary
- Track the requestAnimationFrame ID in the game loop and expose a stopGameLoop helper
- Reset timing counters and return frame ID when starting the loop
- Use a cleanup function in App to cancel the loop when unmounting

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c16612390c83288724ce8a9c6c488d