### PR TITLE
Rename core UI terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,19 @@ npm run build # create production build
 
 - Expand generator balance and progression
 - Add upgrades and multipliers
-- Prestige/reset system
+- Polta sauna/reset system
 - Achievements and statistics
 
-## Prestige (Polta sauna)
+## Polta sauna
 
-Reset your population, buildings, technologies and tier level for a permanent population-per-second multiplier.  Prestige points follow a square-root curve based on lifetime population:
+Reset your lämpötila, buildings, technologies and sauna level for a permanent lämpötila-per-second multiplier.  Polta sauna points follow a square-root curve based on lifetime lämpötila:
 
 ```
 points = floor( sqrt(totalPopulation / 100000) )
 multiplier = 1 + points * 0.10
 ```
 
-The prestige button unlocks at 10 000 total population and displays your current multiplier and projected gain.
+The Polta sauna button unlocks at 10 000 total lämpötila and displays your current multiplier and projected gain.
 
 ## License
 

--- a/src/components/BuildingsGrid.tsx
+++ b/src/components/BuildingsGrid.tsx
@@ -22,7 +22,7 @@ export function BuildingsGrid() {
             key={b.id}
             icon={`${import.meta.env.BASE_URL}assets/buildings/${b.icon}`}
             title={`${b.name} (${count})`}
-            subtitle={`Next: ${Math.round(price)} | +${cpsDelta.toFixed(2)} CPS`}
+            subtitle={`Next: ${Math.round(price)} | +${cpsDelta.toFixed(2)} LPS`}
             disabled={disabled}
             onClick={() => buy(b.id)}
           />

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -6,7 +6,7 @@ export function HUD() {
   const click = useGameStore((s) => s.clickPower);
   return (
     <div>
-      <div>Population: {Math.floor(population)}</div>
+      <div>Lämpötila: {Math.floor(population)}</div>
       <button onClick={() => addPopulation(click)}>Click</button>
     </div>
   );

--- a/src/components/Prestige.tsx
+++ b/src/components/Prestige.tsx
@@ -10,20 +10,20 @@ export function Prestige() {
   const next = getTier(tierLevel + 1);
   return (
     <div>
-      <h2>Tiers</h2>
+      <h2>Uusi sauna</h2>
       <div>
-        Tier Level: {tierLevel}
+        Uusi sauna Level: {tierLevel}
         {current ? ` (${current.name})` : ''}
       </div>
       {next && (
         <div>
-          Next Tier: {next.name} ({next.population})
+          Next Uusi sauna: {next.name} ({next.population})
         </div>
       )}
       <button disabled={!canAdvance} onClick={() => advance()}>
-        Advance Tier
+        Advance Uusi sauna
       </button>
-      <div>Population: {Math.floor(population)}</div>
+      <div>Lämpötila: {Math.floor(population)}</div>
     </div>
   );
 }

--- a/src/components/PrestigeCard.tsx
+++ b/src/components/PrestigeCard.tsx
@@ -27,17 +27,18 @@ export function PrestigeCard() {
 
   const subtitle = canPrestige
     ? `Gain +${(deltaMult * 100).toFixed(0)}% → ${multAfter.toFixed(2)}×`
-    : `Unlock at ${prestigeData.minPopulation} population`;
+    : `Unlock at ${prestigeData.minPopulation} lämpötila`;
 
   return (
     <ImageCardButton
       icon={prestigeData.icon}
-      title={`Prestige: ${prestigeMult.toFixed(2)}×`}
+      title={`${prestigeData.name}: ${prestigeMult.toFixed(2)}×`}
       subtitle={subtitle}
       disabled={!canPrestige}
       onClick={() => {
         if (!canPrestige) return;
-        if (confirm('Reset progress and gain prestige multiplier?')) prestige();
+        if (confirm(`Reset progress and gain ${prestigeData.name} multiplier?`))
+          prestige();
       }}
     />
   );

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -19,14 +19,14 @@ describe('model v3', () => {
     useGameStore.getState().recompute();
   });
 
-  it('CPS increases when buying buildings', () => {
+  it('LPS increases when buying buildings', () => {
     useGameStore.setState({ population: 1000 });
     const before = useGameStore.getState().cps;
     useGameStore.getState().purchaseBuilding('sauna');
     expect(useGameStore.getState().cps).toBeGreaterThan(before);
   });
 
-  it("Tech 'vihta' multiplies CPS", () => {
+  it("Tech 'vihta' multiplies LPS", () => {
     useGameStore.setState({ population: 1000 });
     useGameStore.getState().purchaseBuilding('sauna');
     const before = useGameStore.getState().cps;

--- a/src/tests/prestige.test.ts
+++ b/src/tests/prestige.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useGameStore, computePrestigePoints, computePrestigeMult } from '../app/store';
 
-describe('prestige', () => {
+describe('polta sauna', () => {
   beforeEach(() => {
     useGameStore.persist.clearStorage();
     useGameStore.setState({
@@ -19,17 +19,17 @@ describe('prestige', () => {
     useGameStore.getState().recompute();
   });
 
-  it('cannot prestige below minimum population', () => {
+  it('cannot polta sauna below minimum lämpötila', () => {
     useGameStore.setState({ totalPopulation: 9999 });
     expect(useGameStore.getState().canPrestige()).toBe(false);
   });
 
-  it('computes points and multiplier at 100k population', () => {
+  it('computes points and multiplier at 100k lämpötila', () => {
     expect(computePrestigePoints(100000)).toBe(1);
     expect(computePrestigeMult(1)).toBeCloseTo(1.1);
   });
 
-  it('prestige resets progress and keeps lifetime stats', () => {
+  it('polta sauna resets progress and keeps lifetime stats', () => {
     useGameStore.setState({
       population: 500,
       totalPopulation: 100000,


### PR DESCRIPTION
## Summary
- Translate display terminology: Population→Lämpötila, CPS→LPS, Prestige→Polta sauna, Tier→Uusi sauna
- Update documentation and tests to reflect new names

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1738a29448328b726d6cba95998e0