### PR TITLE
fix asset paths for subpath deployments

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ function App() {
   }, []);
   useEffect(() => {
     const body = document.body;
-    body.style.backgroundImage = `url(/assets/backgrounds/tier${tierLevel}.svg)`;
+    body.style.backgroundImage = `url(${import.meta.env.BASE_URL}assets/backgrounds/tier${tierLevel}.svg)`;
     body.style.backgroundSize = 'cover';
     body.style.backgroundPosition = 'center';
     body.style.backgroundRepeat = 'no-repeat';

--- a/src/content/prestige.json
+++ b/src/content/prestige.json
@@ -1,7 +1,7 @@
 {
   "id": "polta_sauna",
   "name": "Polta sauna",
-  "icon": "/assets/ui/torch.png",
+  "icon": "assets/ui/torch.png",
   "minPopulation": 10000,
   "formula": {
     "type": "sqrt",


### PR DESCRIPTION
## Summary
- make prestige torch icon path relative so it respects the configured base URL
- ensure tier background images use `import.meta.env.BASE_URL`

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c188a231948328a85fd009bc83c582