### PR TITLE
refactor: extract card styling into shared class with gradient text overlay

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -33,10 +33,6 @@
   }
 }
 
-.card {
-  padding: 2em;
-}
-
 .read-the-docs {
   color: #888;
 }

--- a/src/components/ImageCardButton.tsx
+++ b/src/components/ImageCardButton.tsx
@@ -15,24 +15,12 @@ export function ImageCardButton({
   onClick,
 }: ImageCardButtonProps) {
   return (
-    <button
-      onClick={onClick}
-      disabled={disabled}
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        margin: 4,
-        padding: 8,
-        border: '1px solid #ccc',
-        background: '#fff',
-        opacity: disabled ? 0.5 : 1,
-        cursor: disabled ? 'default' : 'pointer',
-      }}
-    >
+    <button onClick={onClick} disabled={disabled} className="card">
       <img src={icon} alt={title} width={96} height={96} />
-      <div>{title}</div>
-      {subtitle && <div>{subtitle}</div>}
+      <div className="card__text">
+        <div>{title}</div>
+        {subtitle && <div>{subtitle}</div>}
+      </div>
     </button>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,7 @@
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
   background-color: #242424;
+  --surface-elevated: #2a2a2a;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -58,6 +59,7 @@ button:focus-visible {
   :root {
     color: #213547;
     background-color: #ffffff;
+    --surface-elevated: #f9f9f9;
   }
   a:hover {
     color: #747bff;
@@ -65,4 +67,28 @@ button:focus-visible {
   button {
     background-color: #f9f9f9;
   }
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 4px;
+  padding: 8px;
+  background-color: var(--surface-elevated);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  border: none;
+  cursor: pointer;
+}
+
+.card:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.card__text {
+  width: 100%;
+  padding: 4px;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0));
+  text-align: center;
 }


### PR DESCRIPTION
## Summary
- move inline ImageCardButton styles into shared `.card` CSS class with elevated background and box shadow
- wrap card text in `.card__text` gradient container and apply classNames
- remove unused `.card` style from App.css

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c19c78211c8328a485861534d6ac08