### PR TITLE
style: add hud styling and typography

### DIFF
--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -5,9 +5,11 @@ export function HUD() {
   const addPopulation = useGameStore((s) => s.addPopulation);
   const click = useGameStore((s) => s.clickPower);
   return (
-    <div>
-      <div>Lämpötila: {Math.floor(population)}</div>
-      <button onClick={() => addPopulation(click)}>Click</button>
+    <div className="hud">
+      <div className="text--h2">Lämpötila: {Math.floor(population)}</div>
+      <button className="text--body" onClick={() => addPopulation(click)}>
+        Click
+      </button>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -54,6 +54,22 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
+/* Heads-up display container */
+.hud {
+  background-color: color-mix(in srgb, var(--surface) 80%, transparent);
+  padding: 1rem;
+}
+
+/* Typography helpers */
+.text--h2 {
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.text--body {
+  font-size: 1rem;
+}
+
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;


### PR DESCRIPTION
## Summary
- style HUD with semi-transparent surface background and padding
- add typography helper classes for headings and body text
- apply new HUD and text classes in HUD component

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c19c8005b88328b71b1f9f9add58d3