### PR TITLE
feat: add primary button styles

### DIFF
--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -7,7 +7,12 @@ export function HUD() {
   return (
     <div>
       <div>Lämpötila: {Math.floor(population)}</div>
-      <button onClick={() => addPopulation(click)}>Click</button>
+      <button
+        className="btn btn--primary"
+        onClick={() => addPopulation(click)}
+      >
+        Click
+      </button>
     </div>
   );
 }

--- a/src/components/ImageCardButton.tsx
+++ b/src/components/ImageCardButton.tsx
@@ -16,6 +16,7 @@ export function ImageCardButton({
 }: ImageCardButtonProps) {
   return (
     <button
+      className="btn btn--primary"
       onClick={onClick}
       disabled={disabled}
       style={{

--- a/src/components/Prestige.tsx
+++ b/src/components/Prestige.tsx
@@ -20,7 +20,11 @@ export function Prestige() {
           Next Uusi sauna: {next.name} ({next.population})
         </div>
       )}
-      <button disabled={!canAdvance} onClick={() => advance()}>
+      <button
+        className="btn btn--primary"
+        disabled={!canAdvance}
+        onClick={() => advance()}
+      >
         Advance Uusi sauna
       </button>
       <div>Lämpötila: {Math.floor(population)}</div>

--- a/src/components/Store.tsx
+++ b/src/components/Store.tsx
@@ -18,7 +18,11 @@ export function Store() {
             <span>
               {b.name} ({count}){' '}
             </span>
-            <button disabled={population < price} onClick={() => buy(b.id)}>
+            <button
+              className="btn btn--primary"
+              disabled={population < price}
+              onClick={() => buy(b.id)}
+            >
               Buy {Math.round(price)}
             </button>
           </div>

--- a/src/components/Upgrades.tsx
+++ b/src/components/Upgrades.tsx
@@ -17,6 +17,7 @@ export function Upgrades() {
               {t.name} ({t.cost})
             </span>
             <button
+              className="btn btn--primary"
               disabled={
                 population < t.cost || (counts[t.id] || 0) >= (t.limit ?? 1)
               }

--- a/src/index.css
+++ b/src/index.css
@@ -1,10 +1,13 @@
 :root {
+  --brand-primary: #646cff;
+  --color-text: rgba(255, 255, 255, 0.87);
+
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
+  color: var(--color-text);
   background-color: #242424;
 
   font-synthesis: none;
@@ -35,34 +38,34 @@ h1 {
   line-height: 1.1;
 }
 
-button {
+.btn {
+  border: none;
   border-radius: 8px;
-  border: 1px solid transparent;
   padding: 0.6em 1.2em;
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
   cursor: pointer;
-  transition: border-color 0.25s;
 }
-button:hover {
-  border-color: #646cff;
+
+.btn--primary {
+  background-color: var(--brand-primary);
+  color: var(--color-text);
 }
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+
+.btn--primary:hover,
+.btn--primary:active,
+.btn--primary:focus-visible {
+  outline: 2px solid var(--color-text);
+  outline-offset: 2px;
 }
 
 @media (prefers-color-scheme: light) {
   :root {
-    color: #213547;
+    --color-text: #213547;
     background-color: #ffffff;
   }
   a:hover {
     color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,7 @@
 :root {
   --brand-primary: #646cff;
   --color-text: rgba(255, 255, 255, 0.87);
+  --color-button-text: #ffffff;
 
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
@@ -50,7 +51,7 @@ h1 {
 
 .btn--primary {
   background-color: var(--brand-primary);
-  color: var(--color-text);
+  color: var(--color-button-text);
 }
 
 .btn--primary:hover,


### PR DESCRIPTION
## Summary
- add shared `.btn` and `.btn--primary` styles with high-contrast states
- use primary button classes across HUD, store, prestige, upgrades, and image card components

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c19c8605d883289da9e2fb4b774ed7