### PR TITLE
Add surface color variable and population HUD overlay

### DIFF
--- a/src/components/Prestige.tsx
+++ b/src/components/Prestige.tsx
@@ -27,7 +27,7 @@ export function Prestige() {
       >
         Uusi sauna!
       </button>
-      <div>Lämpötila: {Math.floor(population)}</div>
+      <div className="hud hud__population">Lämpötila: {Math.floor(population)}</div>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -10,6 +10,7 @@
   color-scheme: light dark;
   color: var(--color-text);
   background-color: #242424;
+  --surface: #1e1e1e;
   --surface-elevated: #2a2a2a;
 
   font-synthesis: none;
@@ -68,6 +69,10 @@ h1 {
   padding: 1rem;
 }
 
+.hud__population {
+  border-radius: 0.5rem;
+}
+
 /* Typography helpers */
 .text--h2 {
   font-size: 1.5rem;
@@ -82,6 +87,7 @@ h1 {
   :root {
     --color-text: #213547;
     background-color: #ffffff;
+    --surface: #ffffff;
     --surface-elevated: #f9f9f9;
   }
   a:hover {


### PR DESCRIPTION
## Summary
- define `--surface` CSS variable for dark and light themes
- style `.hud` overlays with `--surface` and introduce `.hud__population`
- wrap Prestige temperature line in the reusable HUD scrim

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1b881c58c83289c714cf46871a607