### PR TITLE
fix: pin prestige button

### DIFF
--- a/src/components/PrestigeCard.tsx
+++ b/src/components/PrestigeCard.tsx
@@ -30,16 +30,25 @@ export function PrestigeCard() {
     : `Unlock at ${prestigeData.minPopulation} lämpötila`;
 
   return (
-    <ImageCardButton
-      icon={prestigeData.icon}
-      title={`${prestigeData.name}: ${prestigeMult.toFixed(2)}×`}
-      subtitle={subtitle}
-      disabled={!canPrestige}
-      onClick={() => {
-        if (!canPrestige) return;
-        if (confirm(`Reset progress and gain ${prestigeData.name} multiplier?`))
-          prestige();
+    <div
+      style={{
+        position: 'fixed',
+        top: '1rem',
+        right: '1rem',
+        zIndex: 1000,
       }}
-    />
+    >
+      <ImageCardButton
+        icon={prestigeData.icon}
+        title={`${prestigeData.name}: ${prestigeMult.toFixed(2)}×`}
+        subtitle={subtitle}
+        disabled={!canPrestige}
+        onClick={() => {
+          if (!canPrestige) return;
+          if (confirm(`Reset progress and gain ${prestigeData.name} multiplier?`))
+            prestige();
+        }}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- pin prestige button to the top-right corner with a fixed container

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1bc2a2abc8328a42998b856bb1515