### PR TITLE
feat: add responsive prestige button

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -6,7 +6,7 @@ import { useGameStore } from './app/store';
 describe('HUD', () => {
   it('increments population on click', () => {
     render(<HUD />);
-    fireEvent.click(screen.getByText(/click/i));
+    fireEvent.click(screen.getByRole('button'));
     expect(useGameStore.getState().population).toBe(1);
   });
 });

--- a/src/components/ImageCardButton.tsx
+++ b/src/components/ImageCardButton.tsx
@@ -5,6 +5,8 @@ interface ImageCardButtonProps {
   subtitle?: string;
   disabled?: boolean;
   onClick: () => void;
+  className?: string;
+  compact?: boolean;
 }
 
 export function ImageCardButton({
@@ -13,12 +15,16 @@ export function ImageCardButton({
   subtitle,
   disabled,
   onClick,
+  className,
+  compact,
 }: ImageCardButtonProps) {
   return (
     <button
-      className="btn btn--primary"
+      className={`btn btn--primary ${className ?? ''}`.trim()}
       onClick={onClick}
       disabled={disabled}
+      data-compact={compact ? '' : undefined}
+      aria-label={compact ? title : undefined}
       style={{
         display: 'flex',
         flexDirection: 'column',
@@ -31,11 +37,18 @@ export function ImageCardButton({
         cursor: disabled ? 'default' : 'pointer',
       }}
     >
-      <img src={icon} alt={title} width={96} height={96} />
-      <div className="card__text">
-        <div>{title}</div>
-        {subtitle && <div>{subtitle}</div>}
-      </div>
+      <img
+        src={icon}
+        alt={title}
+        width={compact ? 48 : 96}
+        height={compact ? 48 : 96}
+      />
+      {!compact && (
+        <div className="card__text">
+          <div>{title}</div>
+          {subtitle && <div>{subtitle}</div>}
+        </div>
+      )}
     </button>
   );
 }

--- a/src/components/PrestigeCard.tsx
+++ b/src/components/PrestigeCard.tsx
@@ -39,6 +39,7 @@ export function PrestigeCard() {
       }}
     >
       <ImageCardButton
+        className="prestige-btn"
         icon={prestigeData.icon}
         title={`${prestigeData.name}: ${prestigeMult.toFixed(2)}×`}
         subtitle={subtitle}

--- a/src/index.css
+++ b/src/index.css
@@ -128,3 +128,19 @@ h1 {
   background: linear-gradient(to top, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0));
   text-align: center;
 }
+
+@media (max-width: 480px) {
+  .prestige-btn {
+    margin: 2px !important;
+    padding: 4px !important;
+  }
+
+  .prestige-btn img {
+    width: 48px;
+    height: 48px;
+  }
+
+  .prestige-btn .card__text {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- allow ImageCardButton to accept a custom class and optional compact mode
- tag Prestige card button for responsive styling
- shrink prestige button and hide its label on narrow screens

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1c1358c088328b00924d611bb905d