### PR TITLE
Show LPS in HUD and add tests

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,12 +1,38 @@
-import { describe, it, expect } from 'vitest';
+import { beforeEach, describe, it, expect } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { HUD } from './components/HUD';
 import { useGameStore } from './app/store';
 
+function resetStore() {
+  useGameStore.setState({
+    population: 0,
+    totalPopulation: 0,
+    tierLevel: 1,
+    buildings: {},
+    techCounts: {},
+    multipliers: { population_cps: 1 },
+    cps: 0,
+    clickPower: 1,
+    prestigePoints: 0,
+    prestigeMult: 1,
+  });
+}
+
 describe('HUD', () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
   it('increments population on click', () => {
     render(<HUD />);
     fireEvent.click(screen.getByRole('button'));
     expect(useGameStore.getState().population).toBe(1);
+  });
+
+  it('renders LPS when cps is set', () => {
+    useGameStore.setState({ cps: 5 });
+    render(<HUD />);
+    expect(screen.getByText(/LPS: 5/)).toBeInTheDocument();
   });
 });

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -1,13 +1,15 @@
 import { useGameStore } from '../app/store';
+import { formatNumber } from '../utils';
 
 export function HUD() {
   const population = useGameStore((s) => s.population);
   const addPopulation = useGameStore((s) => s.addPopulation);
   const click = useGameStore((s) => s.clickPower);
+  const cps = useGameStore((s) => s.cps);
   return (
     <div>
       <div className="hud hud__population">
-        Lämpötila: {Math.floor(population)}
+        Lämpötila: {Math.floor(population)} | LPS: {formatNumber(cps)}
       </div>
       <button
         className="btn btn--primary"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,3 @@
+export function formatNumber(value: number): string {
+  return value.toLocaleString(undefined, { maximumFractionDigits: 2 });
+}


### PR DESCRIPTION
## Summary
- display current LPS alongside population using new `formatNumber` helper
- add tests ensuring LPS renders when cps is set and reset store between tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3e73a50a08328963e9223fcf93587