### PR TITLE
feat: add number formatting utility

### DIFF
--- a/src/components/BuildingsGrid.tsx
+++ b/src/components/BuildingsGrid.tsx
@@ -1,5 +1,6 @@
 import { useGameStore } from '../app/store';
 import { buildings, getBuildingCost } from '../content';
+import { formatNumber } from '../utils/format';
 import { ImageCardButton } from './ImageCardButton';
 
 export function BuildingsGrid() {
@@ -21,8 +22,8 @@ export function BuildingsGrid() {
           <ImageCardButton
             key={b.id}
             icon={`${import.meta.env.BASE_URL}assets/buildings/${b.icon}`}
-            title={`${b.name} (${count})`}
-            subtitle={`Next: ${Math.round(price)} | +${cpsDelta.toFixed(2)} LPS`}
+            title={`${b.name} (${formatNumber(count)})`}
+            subtitle={`Next: ${formatNumber(price)} | +${formatNumber(cpsDelta)} LPS`}
             disabled={disabled}
             onClick={() => buy(b.id)}
           />

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -1,5 +1,5 @@
 import { useGameStore } from '../app/store';
-import { formatNumber } from '../utils';
+import { formatNumber } from '../utils/format';
 
 export function HUD() {
   const population = useGameStore((s) => s.population);
@@ -9,7 +9,7 @@ export function HUD() {
   return (
     <div>
       <div className="hud hud__population">
-        Lämpötila: {Math.floor(population)} | LPS: {formatNumber(cps)}
+        Lämpötila: {formatNumber(population)} | LPS: {formatNumber(cps)}
       </div>
       <button
         className="btn btn--primary"

--- a/src/components/Prestige.tsx
+++ b/src/components/Prestige.tsx
@@ -1,5 +1,6 @@
 import { useGameStore } from '../app/store';
 import { getTier } from '../content';
+import { formatNumber } from '../utils/format';
 
 export function Prestige() {
   const tierLevel = useGameStore((s) => s.tierLevel);
@@ -11,12 +12,12 @@ export function Prestige() {
     <div className="hud hud__card">
       <h2 className="text--h2">Uusi sauna</h2>
       <div className="text--body">
-        Sauna Taso: {tierLevel}
+        Sauna Taso: {formatNumber(tierLevel)}
         {current ? ` (${current.name})` : ''}
       </div>
       {next && (
         <div className="text--body">
-          Next Sauna: {next.name} ({next.population})
+          Next Sauna: {next.name} ({formatNumber(next.population)})
         </div>
       )}
       <button

--- a/src/components/PrestigeCard.tsx
+++ b/src/components/PrestigeCard.tsx
@@ -6,6 +6,7 @@ import {
   useGameStore,
 } from '../app/store';
 import { prestige as prestigeData } from '../content';
+import { formatNumber } from '../utils/format';
 
 export function PrestigeCard() {
   const prestigePoints = useGameStore((s) => s.prestigePoints);
@@ -26,8 +27,8 @@ export function PrestigeCard() {
   }, [prestigePoints, prestigeMult, totalPopulation]);
 
   const subtitle = canPrestige
-    ? `Gain +${(deltaMult * 100).toFixed(0)}% → ${multAfter.toFixed(2)}×`
-    : `Unlock at ${prestigeData.minPopulation} lämpötila`;
+    ? `Gain +${formatNumber(deltaMult * 100)}% → ${formatNumber(multAfter)}×`
+    : `Unlock at ${formatNumber(prestigeData.minPopulation)} lämpötila`;
 
   return (
     <div
@@ -41,7 +42,7 @@ export function PrestigeCard() {
       <ImageCardButton
         className="prestige-btn"
         icon={prestigeData.icon}
-        title={`${prestigeData.name}: ${prestigeMult.toFixed(2)}×`}
+        title={`${prestigeData.name}: ${formatNumber(prestigeMult)}×`}
         subtitle={subtitle}
         disabled={!canPrestige}
         onClick={() => {

--- a/src/components/Store.tsx
+++ b/src/components/Store.tsx
@@ -1,5 +1,6 @@
 import { useGameStore } from '../app/store';
 import { buildings, getBuildingCost } from '../content';
+import { formatNumber } from '../utils/format';
 
 export function Store() {
   const buy = useGameStore((s) => s.purchaseBuilding);
@@ -16,14 +17,14 @@ export function Store() {
         return (
           <div key={b.id}>
             <span>
-              {b.name} ({count}){' '}
+              {b.name} ({formatNumber(count)}){' '}
             </span>
             <button
               className="btn btn--primary"
               disabled={population < price}
               onClick={() => buy(b.id)}
             >
-              Buy {Math.round(price)}
+              Buy {formatNumber(price)}
             </button>
           </div>
         );

--- a/src/components/TechGrid.tsx
+++ b/src/components/TechGrid.tsx
@@ -1,5 +1,6 @@
 import { useGameStore } from '../app/store';
 import { tech } from '../content';
+import { formatNumber } from '../utils/format';
 import { ImageCardButton } from './ImageCardButton';
 
 export function TechGrid() {
@@ -18,7 +19,7 @@ export function TechGrid() {
         const disabled = isOwned || locked || population < t.cost;
         const subtitle = `${isOwned ? 'Owned' : locked ? 'Locked' : ''}${
           isOwned || locked ? ' - ' : ''
-        }Cost: ${Math.round(t.cost)}`;
+        }Cost: ${formatNumber(t.cost)}`;
         return (
           <ImageCardButton
             key={t.id}

--- a/src/components/Upgrades.tsx
+++ b/src/components/Upgrades.tsx
@@ -1,5 +1,6 @@
 import { useGameStore } from '../app/store';
 import { tech as techList } from '../content';
+import { formatNumber } from '../utils/format';
 
 export function Upgrades() {
   const population = useGameStore((s) => s.population);
@@ -14,7 +15,7 @@ export function Upgrades() {
         return (
           <div key={t.id}>
             <span>
-              {t.name} ({t.cost})
+              {t.name} ({formatNumber(t.cost)})
             </span>
             <button
               className="btn btn--primary"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,0 @@
-export function formatNumber(value: number): string {
-  return value.toLocaleString(undefined, { maximumFractionDigits: 2 });
-}

--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { formatNumber } from './format';
+
+describe('formatNumber', () => {
+  it('formats numbers below 1e6 without exponent', () => {
+    expect(formatNumber(999999)).toBe('999,999');
+  });
+
+  it('formats numbers at or above 1e6 in scientific notation', () => {
+    expect(formatNumber(1000000)).toBe('1.00e+6');
+  });
+});

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,6 @@
+export function formatNumber(n: number): string {
+  if (Math.abs(n) < 1e6) {
+    return n.toLocaleString(undefined, { maximumFractionDigits: 2 });
+  }
+  return n.toExponential(2);
+}


### PR DESCRIPTION
## Summary
- add shared `formatNumber` utility for plain and scientific notation
- use `formatNumber` for costs, counts, and LPS across UI
- cover edge-case formatting with new tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3e8d042ec8328952f53116de1973e