### PR TITLE
Lazy load audio assets

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,7 @@ function App() {
     };
   }, [tierLevel]);
   useEffect(() => {
-    playTierMusic(tierLevel);
+    void playTierMusic(tierLevel);
   }, [tierLevel]);
   return (
     <>

--- a/src/assets.d.ts
+++ b/src/assets.d.ts
@@ -1,0 +1,4 @@
+declare module '*.mp3' {
+  const src: string;
+  export default src;
+}

--- a/src/audio/music.ts
+++ b/src/audio/music.ts
@@ -1,19 +1,34 @@
 class MusicController {
   private currentTier: number | null = null;
   private audio: HTMLAudioElement | null = null;
+  private cache = new Map<number, Promise<HTMLAudioElement>>();
 
-  playForTier(tier: number) {
+  private loadTrack(tier: number): Promise<HTMLAudioElement> {
+    let track = this.cache.get(tier);
+    if (!track) {
+      track = import(
+        /* @vite-ignore */ `${import.meta.env.BASE_URL}assets/music/tier${tier}.mp3`
+      ).then((mod) => {
+        const { default: src } = mod as { default: string };
+        const audio = new Audio(src);
+        audio.loop = true;
+        return audio;
+      });
+      this.cache.set(tier, track);
+    }
+    return track;
+  }
+
+  async playForTier(tier: number) {
     if (this.currentTier === tier) return;
     this.currentTier = tier;
-
-    const src = `${import.meta.env.BASE_URL}assets/music/tier${tier}.mp3`;
 
     if (this.audio) {
       this.audio.pause();
     }
 
-    this.audio = new Audio(src);
-    this.audio.loop = true;
+    this.audio = await this.loadTrack(tier);
+    this.audio.currentTime = 0;
     // Attempt to play; ignore errors (e.g. autoplay restrictions)
     this.audio.play().catch(() => {});
   }

--- a/src/audio/sfx.ts
+++ b/src/audio/sfx.ts
@@ -1,0 +1,18 @@
+const cache: Record<string, Promise<HTMLAudioElement>> = {};
+
+export const playSfx = async (name: string) => {
+  let promise = cache[name];
+  if (!promise) {
+    promise = import(
+      /* @vite-ignore */ `${import.meta.env.BASE_URL}assets/sfx/${name}.mp3`
+    ).then((mod) => {
+      const { default: src } = mod as { default: string };
+      return new Audio(src);
+    });
+    cache[name] = promise;
+  }
+  const audio = await promise;
+  audio.currentTime = 0;
+  // Attempt to play; ignore errors (e.g. autoplay restrictions)
+  audio.play().catch(() => {});
+};


### PR DESCRIPTION
## Summary
- Load tier music via dynamic import with caching so tracks download only when a tier is entered
- Add sound effects module that lazily imports and reuses each effect on first use
- Trigger music loading asynchronously on tier change and declare mp3 module types

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3f0f741a8832896daecc9fa1089c4