### PR TITLE
feat: add offline progress

### DIFF
--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -100,4 +100,29 @@ describe('model v3', () => {
     expect(state.techCounts.vihta).toBeUndefined();
     expect(state.tierLevel).toBe(1);
   });
+
+  it('grants offline progress based on elapsed time', async () => {
+    const fiveSecondsAgo = Date.now() - 5000;
+    const payload = {
+      state: {
+        population: 100,
+        totalPopulation: 100,
+        tierLevel: 1,
+        buildings: { kylakauppa: 2 },
+        techCounts: {},
+        multipliers: { population_cps: 1 },
+        cps: 0,
+        clickPower: 1,
+        prestigePoints: 0,
+        prestigeMult: 1,
+        lastSave: fiveSecondsAgo,
+      },
+      version: 3,
+    };
+    localStorage.setItem('suomidle', JSON.stringify(payload));
+    await useGameStore.persist.rehydrate();
+    const state = useGameStore.getState();
+    expect(state.population).toBeCloseTo(110);
+    expect(state.totalPopulation).toBeCloseTo(110);
+  });
 });


### PR DESCRIPTION
## Summary
- add lastSave timestamp to game state
- award offline gains when rehydrating the store
- test offline progress

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3f58cf7e88328952b8dcb0a6b2de7