### PR TITLE
feat: show polta sauna multiplier on mobile

### DIFF
--- a/src/components/PrestigeCard.tsx
+++ b/src/components/PrestigeCard.tsx
@@ -26,6 +26,8 @@ export function PrestigeCard() {
     };
   }, [prestigePoints, prestigeMult, totalPopulation]);
 
+  const prestigePercent = (prestigeMult - 1) * 100;
+
   const subtitle = canPrestige
     ? `Gain +${formatNumber(deltaMult * 100)}% → ${formatNumber(multAfter)}×`
     : `Unlock at ${formatNumber(prestigeData.minPopulation)} lämpötila`;
@@ -37,6 +39,9 @@ export function PrestigeCard() {
         top: '1rem',
         right: '1rem',
         zIndex: 1000,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
       }}
     >
       <ImageCardButton
@@ -47,10 +52,19 @@ export function PrestigeCard() {
         disabled={!canPrestige}
         onClick={() => {
           if (!canPrestige) return;
-          if (confirm(`Reset progress and gain ${prestigeData.name} multiplier?`))
+          if (
+            confirm(
+              `Reset progress and gain +${formatNumber(
+                deltaMult * 100,
+              )}% ${prestigeData.name} multiplier?`,
+            )
+          )
             prestige();
         }}
       />
+      <div className="prestige-mobile-info">
+        {`Polta sauna: +${formatNumber(prestigePercent)}%`}
+      </div>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -129,6 +129,11 @@ h1 {
   text-align: center;
 }
 
+.prestige-mobile-info {
+  display: none;
+  font-size: 0.8rem;
+}
+
 @media (max-width: 480px) {
   .prestige-btn {
     margin: 2px !important;
@@ -142,5 +147,10 @@ h1 {
 
   .prestige-btn .card__text {
     display: none;
+  }
+
+  .prestige-mobile-info {
+    display: block;
+    margin-top: 0.25rem;
   }
 }


### PR DESCRIPTION
## Summary
- show current polta sauna multiplier on mobile view
- include upcoming multiplier in polta sauna warning

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3f75287e083289f81524669f439c9