### PR TITLE
Add settings menu with sound controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { startGameLoop, stopGameLoop } from './app/gameLoop';
 import { useGameStore } from './app/store';
 import './App.css';
 import { playTierMusic } from './audio/music';
+import { Settings } from './components/Settings';
 
 function App() {
   const tierLevel = useGameStore((s) => s.tierLevel);
@@ -35,6 +36,7 @@ function App() {
   }, [tierLevel]);
   return (
     <>
+      <Settings />
       <HUD />
       <PrestigeCard />
       <BuildingsGrid />

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -28,6 +28,8 @@ interface State {
   clickPower: number;
   prestigePoints: number;
   prestigeMult: number;
+  soundEnabled: boolean;
+  volume: number;
   addPopulation: (amount: number) => void;
   purchaseBuilding: (id: string) => void;
   purchaseTech: (id: string) => void;
@@ -44,6 +46,8 @@ interface State {
     deltaMult: number;
   };
   prestige: () => boolean;
+  setSoundEnabled: (enabled: boolean) => void;
+  setVolume: (volume: number) => void;
 }
 
 const initialState = {
@@ -57,6 +61,8 @@ const initialState = {
   clickPower: 1,
   prestigePoints: 0,
   prestigeMult: 1,
+  soundEnabled: true,
+  volume: 1,
 };
 
 export const computePrestigePoints = (totalPop: number) => {
@@ -175,6 +181,8 @@ export const useGameStore = create<State>()(
         saveGame();
         return true;
       },
+      setSoundEnabled: (enabled) => set({ soundEnabled: enabled }),
+      setVolume: (volume) => set({ volume }),
     }),
     {
       name: 'suomidle',
@@ -196,6 +204,9 @@ export const useGameStore = create<State>()(
               typeof old?.prestigePoints === 'number' ? (old.prestigePoints as number) : 0,
             prestigeMult:
               typeof old?.prestigeMult === 'number' ? (old.prestigeMult as number) : 1,
+            soundEnabled:
+              typeof old?.soundEnabled === 'boolean' ? (old.soundEnabled as boolean) : true,
+            volume: typeof old?.volume === 'number' ? (old.volume as number) : 1,
           };
         }
 
@@ -246,6 +257,9 @@ export const useGameStore = create<State>()(
           clickPower: 1,
           prestigePoints: 0,
           prestigeMult: 1,
+          soundEnabled:
+            typeof old?.soundEnabled === 'boolean' ? (old.soundEnabled as boolean) : true,
+          volume: typeof old?.volume === 'number' ? (old.volume as number) : 1,
         };
       },
       onRehydrateStorage: () => undefined,
@@ -266,6 +280,8 @@ export const saveGame = () => {
   delete rest.canPrestige;
   delete rest.projectPrestigeGain;
   delete rest.prestige;
+  delete rest.setSoundEnabled;
+  delete rest.setVolume;
   const data = { state: rest, version: 3 };
   localStorage.setItem('suomidle', JSON.stringify(data));
 };

--- a/src/audio/sfx.ts
+++ b/src/audio/sfx.ts
@@ -1,6 +1,10 @@
+import { useGameStore } from '../app/store';
+
 const cache: Record<string, Promise<HTMLAudioElement>> = {};
 
 export const playSfx = async (name: string) => {
+  const { soundEnabled, volume } = useGameStore.getState();
+  if (!soundEnabled || volume === 0) return;
   let promise = cache[name];
   if (!promise) {
     promise = import(
@@ -13,6 +17,7 @@ export const playSfx = async (name: string) => {
   }
   const audio = await promise;
   audio.currentTime = 0;
+  audio.volume = volume;
   // Attempt to play; ignore errors (e.g. autoplay restrictions)
   audio.play().catch(() => {});
 };

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { useGameStore } from '../app/store';
+import { updateMusicSettings } from '../audio/music';
+
+export function Settings() {
+  const [open, setOpen] = useState(false);
+  const soundEnabled = useGameStore((s) => s.soundEnabled);
+  const volume = useGameStore((s) => s.volume);
+  const setSoundEnabled = useGameStore((s) => s.setSoundEnabled);
+  const setVolume = useGameStore((s) => s.setVolume);
+
+  const toggleSound = (enabled: boolean) => {
+    setSoundEnabled(enabled);
+    updateMusicSettings();
+  };
+
+  const changeVolume = (v: number) => {
+    setVolume(v);
+    updateMusicSettings();
+  };
+
+  return (
+    <div className="settings">
+      <button className="settings__btn" onClick={() => setOpen(!open)}>
+        ☰
+      </button>
+      {open && (
+        <div className="settings__panel hud">
+          <label>
+            <input
+              type="checkbox"
+              checked={soundEnabled}
+              onChange={(e) => toggleSound(e.target.checked)}
+            />{' '}
+            Sound
+          </label>
+          <label>
+            Volume
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.01}
+              value={volume}
+              onChange={(e) => changeVolume(Number(e.target.value))}
+            />
+          </label>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -144,3 +144,44 @@ h1 {
     display: none;
   }
 }
+
+/* Settings menu */
+.settings {
+  position: fixed;
+  top: 0.5rem;
+  left: 0.5rem;
+  z-index: 1000;
+}
+
+.settings__btn {
+  background: var(--surface);
+  color: var(--color-text);
+  border: none;
+  border-radius: 0.25rem;
+  width: 32px;
+  height: 32px;
+  font-size: 1.25rem;
+  cursor: pointer;
+}
+
+@media (min-width: 768px) {
+  .settings__btn {
+    width: 48px;
+    height: 48px;
+    font-size: 1.5rem;
+  }
+}
+
+.settings__panel {
+  margin-top: 0.5rem;
+  background: var(--surface-elevated);
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+}
+
+.settings__panel label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.25rem 0;
+}

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -15,6 +15,8 @@ describe('model v3', () => {
       clickPower: 1,
       prestigePoints: 0,
       prestigeMult: 1,
+      soundEnabled: true,
+      volume: 1,
     });
     useGameStore.getState().recompute();
   });


### PR DESCRIPTION
## Summary
- Add top-left settings menu with responsive burger button
- Allow toggling sound and adjusting volume via global store
- Apply sound settings to background music and sound effects

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3f66cfdcc8328bdad0fbab245ffce