### PR TITLE
Fix tier music glob paths

### DIFF
--- a/src/audio/music.ts
+++ b/src/audio/music.ts
@@ -1,4 +1,6 @@
-const trackImports = import.meta.glob('/assets/music/tier*.mp3');
+// Import all tier music tracks from the public assets directory so Vite
+// bundles them and makes them available at runtime.
+const trackImports = import.meta.glob('/public/assets/music/tier*.mp3');
 
 class MusicController {
   private currentTier: number | null = null;
@@ -8,7 +10,8 @@ class MusicController {
   private loadTrack(tier: number): Promise<HTMLAudioElement> {
     let track = this.cache.get(tier);
     if (!track) {
-      const importer = trackImports[`/assets/music/tier${tier}.mp3`];
+      // Use the same key format as the glob above when selecting the importer
+      const importer = trackImports[`/public/assets/music/tier${tier}.mp3`];
       if (!importer) {
         return Promise.reject(new Error(`Unknown track for tier ${tier}`));
       }


### PR DESCRIPTION
## Summary
- ensure music tracks are imported from the public assets directory
- select track importers using the correct key

## Testing
- `npm test`
- `npm run build`
- `npx vite-node test-tier6.ts` *(manual script verifying tier6 track plays without unknown track error)*

------
https://chatgpt.com/codex/tasks/task_e_68c3f957b8548328a3412f3ea3a837c5