### PR TITLE
Gate audio until first user interaction

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -36,3 +36,15 @@
 .read-the-docs {
   color: #888;
 }
+
+.tap-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  font-size: 2rem;
+  z-index: 1000;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,9 +8,12 @@ import { startGameLoop, stopGameLoop } from './app/gameLoop';
 import { useGameStore } from './app/store';
 import './App.css';
 import { playTierMusic } from './audio/music';
+import { useSettingsStore } from './app/settingsStore';
 
 function App() {
   const tierLevel = useGameStore((s) => s.tierLevel);
+  const hasInteracted = useSettingsStore((s) => s.hasInteracted);
+  const markInteracted = useSettingsStore((s) => s.markInteracted);
   useEffect(() => {
     startGameLoop();
     return () => {
@@ -33,8 +36,20 @@ function App() {
   useEffect(() => {
     void playTierMusic(tierLevel);
   }, [tierLevel]);
+  useEffect(() => {
+    const handler = () => markInteracted();
+    window.addEventListener('keydown', handler, { once: true });
+    return () => {
+      window.removeEventListener('keydown', handler);
+    };
+  }, [markInteracted]);
   return (
     <>
+      {!hasInteracted && (
+        <div className="tap-overlay" onPointerDown={markInteracted}>
+          Tap to start
+        </div>
+      )}
       <HUD />
       <PrestigeCard />
       <BuildingsGrid />

--- a/src/app/settingsStore.ts
+++ b/src/app/settingsStore.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand';
+
+interface SettingsState {
+  hasInteracted: boolean;
+  queue: HTMLAudioElement[];
+  markInteracted: () => void;
+  enqueueAudio: (audio: HTMLAudioElement) => void;
+}
+
+export const useSettingsStore = create<SettingsState>((set, get) => ({
+  hasInteracted: false,
+  queue: [],
+  markInteracted: () => {
+    if (get().hasInteracted) return;
+    const queued = get().queue;
+    set({ hasInteracted: true, queue: [] });
+    for (const audio of queued) {
+      // Attempt to play; ignore errors (e.g. autoplay restrictions)
+      audio.play().catch(() => {});
+    }
+  },
+  enqueueAudio: (audio: HTMLAudioElement) => {
+    if (get().hasInteracted) {
+      audio.play().catch(() => {});
+    } else {
+      set((s) => ({ queue: [...s.queue, audio] }));
+    }
+  },
+}));

--- a/src/audio/music.ts
+++ b/src/audio/music.ts
@@ -1,6 +1,7 @@
 // Import all tier music tracks from the public assets directory so Vite
 // bundles them and makes them available at runtime.
 const trackImports = import.meta.glob('/public/assets/music/tier*.mp3');
+import { useSettingsStore } from '../app/settingsStore';
 
 class MusicController {
   private currentTier: number | null = null;
@@ -36,8 +37,7 @@ class MusicController {
 
     this.audio = await this.loadTrack(tier);
     this.audio.currentTime = 0;
-    // Attempt to play; ignore errors (e.g. autoplay restrictions)
-    this.audio.play().catch(() => {});
+    useSettingsStore.getState().enqueueAudio(this.audio);
   }
 }
 

--- a/src/audio/sfx.ts
+++ b/src/audio/sfx.ts
@@ -1,5 +1,6 @@
 const cache: Record<string, Promise<HTMLAudioElement>> = {};
 const sfxImports = import.meta.glob('/assets/sfx/*.mp3');
+import { useSettingsStore } from '../app/settingsStore';
 
 export const playSfx = async (name: string): Promise<HTMLAudioElement> => {
   let promise = cache[name];
@@ -16,7 +17,6 @@ export const playSfx = async (name: string): Promise<HTMLAudioElement> => {
   }
   const audio = await promise;
   audio.currentTime = 0;
-  // Attempt to play; ignore errors (e.g. autoplay restrictions)
-  audio.play().catch(() => {});
+  useSettingsStore.getState().enqueueAudio(audio);
   return audio;
 };

--- a/src/tests/audioInteraction.test.ts
+++ b/src/tests/audioInteraction.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useSettingsStore } from '../app/settingsStore';
+
+describe('audio interaction gating', () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ hasInteracted: false, queue: [] });
+  });
+
+  it('does not play audio before interaction', () => {
+    const audio = { play: vi.fn().mockResolvedValue(undefined) } as unknown as HTMLAudioElement;
+    useSettingsStore.getState().enqueueAudio(audio);
+    expect(audio.play).not.toHaveBeenCalled();
+  });
+
+  it('plays queued audio after interaction', () => {
+    const audio = { play: vi.fn().mockResolvedValue(undefined) } as unknown as HTMLAudioElement;
+    useSettingsStore.getState().enqueueAudio(audio);
+    expect(audio.play).not.toHaveBeenCalled();
+    useSettingsStore.getState().markInteracted();
+    expect(audio.play).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add settings store that tracks user interaction and queues audio playback
- defer music and sfx `play()` calls until interaction and show tap-to-start overlay
- test that audio is silent before interaction and plays after

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c40752f4fc832880841252da8ea945