### PR TITLE
Add settings menu with sound controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,13 +4,16 @@ import { BuildingsGrid } from './components/BuildingsGrid';
 import { TechGrid } from './components/TechGrid';
 import { Prestige } from './components/Prestige';
 import { PrestigeCard } from './components/PrestigeCard';
+import { Settings } from './components/Settings';
 import { startGameLoop, stopGameLoop } from './app/gameLoop';
 import { useGameStore } from './app/store';
 import './App.css';
-import { playTierMusic } from './audio/music';
+import { playTierMusic, setMusicVolume, stopMusic } from './audio/music';
 
 function App() {
   const tierLevel = useGameStore((s) => s.tierLevel);
+  const volume = useGameStore((s) => s.volume);
+  const soundEnabled = useGameStore((s) => s.soundEnabled);
   useEffect(() => {
     startGameLoop();
     return () => {
@@ -31,10 +34,16 @@ function App() {
     };
   }, [tierLevel]);
   useEffect(() => {
-    void playTierMusic(tierLevel);
-  }, [tierLevel]);
+    if (soundEnabled && volume > 0) {
+      void playTierMusic(tierLevel);
+      setMusicVolume(volume);
+    } else {
+      stopMusic();
+    }
+  }, [tierLevel, soundEnabled, volume]);
   return (
     <>
+      <Settings />
       <HUD />
       <PrestigeCard />
       <BuildingsGrid />

--- a/src/audio/sfx.ts
+++ b/src/audio/sfx.ts
@@ -1,7 +1,13 @@
 const cache: Record<string, Promise<HTMLAudioElement>> = {};
 const sfxImports = import.meta.glob('/assets/sfx/*.mp3');
+import { useGameStore } from '../app/store';
 
-export const playSfx = async (name: string): Promise<HTMLAudioElement> => {
+export const playSfx = async (
+  name: string,
+): Promise<HTMLAudioElement | null> => {
+  const { soundEnabled, volume } = useGameStore.getState();
+  if (!soundEnabled || volume === 0) return null;
+
   let promise = cache[name];
   if (!promise) {
     const importer = sfxImports[`/assets/sfx/${name}.mp3`];
@@ -16,6 +22,7 @@ export const playSfx = async (name: string): Promise<HTMLAudioElement> => {
   }
   const audio = await promise;
   audio.currentTime = 0;
+  audio.volume = volume;
   // Attempt to play; ignore errors (e.g. autoplay restrictions)
   audio.play().catch(() => {});
   return audio;

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import { useGameStore } from '../app/store';
+
+export function Settings() {
+  const [open, setOpen] = useState(false);
+  const soundEnabled = useGameStore((s) => s.soundEnabled);
+  const volume = useGameStore((s) => s.volume);
+  const setSoundEnabled = useGameStore((s) => s.setSoundEnabled);
+  const setVolume = useGameStore((s) => s.setVolume);
+  return (
+    <div className="settings">
+      <button
+        className="settings__button"
+        onClick={() => setOpen((o) => !o)}
+        aria-label="settings"
+      >
+        ☰
+      </button>
+      {open && (
+        <div className="settings__panel">
+          <label className="settings__row">
+            <input
+              type="checkbox"
+              checked={soundEnabled}
+              onChange={(e) => setSoundEnabled(e.target.checked)}
+            />
+            Sound
+          </label>
+          <label className="settings__row">
+            Volume
+            <input
+              type="range"
+              min="0"
+              max="1"
+              step="0.05"
+              value={volume}
+              onChange={(e) => setVolume(Number(e.target.value))}
+            />
+          </label>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -154,3 +154,48 @@ h1 {
     margin-top: 0.25rem;
   }
 }
+
+/* Settings menu */
+.settings {
+  position: fixed;
+  top: 0.5rem;
+  left: 0.5rem;
+  z-index: 1000;
+}
+
+.settings__button {
+  background-color: var(--surface-elevated);
+  color: var(--color-text);
+  border: none;
+  border-radius: 4px;
+  width: 32px;
+  height: 32px;
+  font-size: 24px;
+  cursor: pointer;
+}
+
+@media (min-width: 600px) {
+  .settings__button {
+    width: 48px;
+    height: 48px;
+    font-size: 32px;
+  }
+}
+
+.settings__panel {
+  margin-top: 0.5rem;
+  padding: 0.5rem;
+  background-color: var(--surface-elevated);
+  border-radius: 4px;
+}
+
+.settings__row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.settings__row:last-child {
+  margin-bottom: 0;
+}

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useGameStore } from './app/store';
 
-describe('model v3', () => {
+describe('model v4', () => {
   beforeEach(() => {
     useGameStore.persist.clearStorage();
     useGameStore.setState({
@@ -15,6 +15,8 @@ describe('model v3', () => {
       clickPower: 1,
       prestigePoints: 0,
       prestigeMult: 1,
+      soundEnabled: true,
+      volume: 1,
     });
     useGameStore.getState().recompute();
   });


### PR DESCRIPTION
## Summary
- Add responsive Settings menu with burger button for sound controls
- Persist sound enable and volume options in game store
- Respect global sound settings for music and sound effects

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4056ded008328837ecaf459a8169a