### PR TITLE
Add settings menu with sound controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { BuildingsGrid } from './components/BuildingsGrid';
 import { TechGrid } from './components/TechGrid';
 import { Prestige } from './components/Prestige';
 import { PrestigeCard } from './components/PrestigeCard';
+import { Settings } from './components/Settings';
 import { startGameLoop, stopGameLoop } from './app/gameLoop';
 import { useGameStore } from './app/store';
 import './App.css';
@@ -50,6 +51,7 @@ function App() {
           Tap to start
         </div>
       )}
+      <Settings />
       <HUD />
       <PrestigeCard />
       <BuildingsGrid />

--- a/src/app/settingsStore.ts
+++ b/src/app/settingsStore.ts
@@ -3,13 +3,21 @@ import { create } from 'zustand';
 interface SettingsState {
   hasInteracted: boolean;
   queue: HTMLAudioElement[];
+  audios: HTMLAudioElement[];
+  soundEnabled: boolean;
+  volume: number;
   markInteracted: () => void;
   enqueueAudio: (audio: HTMLAudioElement) => void;
+  setSoundEnabled: (enabled: boolean) => void;
+  setVolume: (volume: number) => void;
 }
 
 export const useSettingsStore = create<SettingsState>((set, get) => ({
   hasInteracted: false,
   queue: [],
+  audios: [],
+  soundEnabled: true,
+  volume: 1,
   markInteracted: () => {
     if (get().hasInteracted) return;
     const queued = get().queue;
@@ -20,10 +28,27 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     }
   },
   enqueueAudio: (audio: HTMLAudioElement) => {
+    audio.volume = get().volume;
+    audio.muted = !get().soundEnabled;
+    set((s) => ({ audios: [...s.audios, audio] }));
     if (get().hasInteracted) {
       audio.play().catch(() => {});
     } else {
       set((s) => ({ queue: [...s.queue, audio] }));
+    }
+  },
+  setSoundEnabled: (enabled: boolean) => {
+    set({ soundEnabled: enabled });
+    const audios = get().audios;
+    for (const audio of audios) {
+      audio.muted = !enabled;
+    }
+  },
+  setVolume: (volume: number) => {
+    set({ volume });
+    const audios = get().audios;
+    for (const audio of audios) {
+      audio.volume = volume;
     }
   },
 }));

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import { useSettingsStore } from '../app/settingsStore';
+
+export function Settings() {
+  const [open, setOpen] = useState(false);
+  const soundEnabled = useSettingsStore((s) => s.soundEnabled);
+  const volume = useSettingsStore((s) => s.volume);
+  const setSoundEnabled = useSettingsStore((s) => s.setSoundEnabled);
+  const setVolume = useSettingsStore((s) => s.setVolume);
+
+  return (
+    <div className="settings">
+      <button
+        aria-label="Settings"
+        className="burger-button"
+        onClick={() => setOpen((o) => !o)}
+      >
+        <span className="line" />
+        <span className="line" />
+        <span className="line" />
+      </button>
+      {open && (
+        <div className="settings-menu">
+          <label>
+            <input
+              type="checkbox"
+              checked={soundEnabled}
+              onChange={(e) => setSoundEnabled(e.target.checked)}
+            />
+            Sound
+          </label>
+          <label>
+            Volume
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.01}
+              value={volume}
+              onChange={(e) => setVolume(Number(e.target.value))}
+            />
+          </label>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -154,3 +154,53 @@ h1 {
     margin-top: 0.25rem;
   }
 }
+
+/* Settings button and menu */
+.settings {
+  position: fixed;
+  top: 0.5rem;
+  left: 0.5rem;
+  z-index: 1000;
+}
+
+.burger-button {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+  background: var(--surface-elevated);
+  border: none;
+  border-radius: 4px;
+  width: 40px;
+  height: 40px;
+  padding: 4px;
+  cursor: pointer;
+}
+
+.burger-button .line {
+  width: 70%;
+  height: 3px;
+  background: var(--color-text);
+}
+
+.settings-menu {
+  margin-top: 0.5rem;
+  background: var(--surface-elevated);
+  padding: 0.75rem;
+  border-radius: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+@media (max-width: 480px) {
+  .burger-button {
+    width: 28px;
+    height: 28px;
+    gap: 3px;
+  }
+  .burger-button .line {
+    height: 2px;
+  }
+}

--- a/src/tests/audioInteraction.test.ts
+++ b/src/tests/audioInteraction.test.ts
@@ -3,7 +3,13 @@ import { useSettingsStore } from '../app/settingsStore';
 
 describe('audio interaction gating', () => {
   beforeEach(() => {
-    useSettingsStore.setState({ hasInteracted: false, queue: [] });
+    useSettingsStore.setState({
+      hasInteracted: false,
+      queue: [],
+      audios: [],
+      soundEnabled: true,
+      volume: 1,
+    });
   });
 
   it('does not play audio before interaction', () => {


### PR DESCRIPTION
## Summary
- add responsive settings button with sound toggle and volume slider
- extend settings store to manage audio volume and mute

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c40a76c40c8328b1fb97ff2624e092