### PR TITLE
Persist rehydrate timestamp to avoid duplicate offline gains

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -260,7 +260,7 @@ export const useGameStore = create<State>()(
         state.recompute();
         const delta = (now - last) / 1000;
         state.tick(delta);
-        state.lastSave = now;
+        useGameStore.setState({ lastSave: now });
       },
     } as PersistOptions<State, Partial<State>>,
   ),

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -125,4 +125,31 @@ describe('model v3', () => {
     expect(state.population).toBeCloseTo(110);
     expect(state.totalPopulation).toBeCloseTo(110);
   });
+
+  it('rehydrating twice in quick succession only grants offline gains once', async () => {
+    const fiveSecondsAgo = Date.now() - 5000;
+    const payload = {
+      state: {
+        population: 100,
+        totalPopulation: 100,
+        tierLevel: 1,
+        buildings: { kylakauppa: 2 },
+        techCounts: {},
+        multipliers: { population_cps: 1 },
+        cps: 0,
+        clickPower: 1,
+        prestigePoints: 0,
+        prestigeMult: 1,
+        lastSave: fiveSecondsAgo,
+      },
+      version: 3,
+    };
+    localStorage.setItem('suomidle', JSON.stringify(payload));
+    await useGameStore.persist.rehydrate();
+    const first = useGameStore.getState().population;
+    await useGameStore.persist.rehydrate();
+    const second = useGameStore.getState().population;
+    expect(first).toBeCloseTo(110, 0);
+    expect(second).toBeCloseTo(first, 0);
+  });
 });


### PR DESCRIPTION
## Summary
- persist `lastSave` in `onRehydrateStorage` via `useGameStore.setState` so state is updated and stored
- add regression test ensuring consecutive rehydrates award offline gains only once

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c40e1028708328a469a3b0b2e05522