### PR TITLE
Persist sound settings across sessions

### DIFF
--- a/src/app/settingsStore.ts
+++ b/src/app/settingsStore.ts
@@ -1,4 +1,9 @@
 import { create } from 'zustand';
+import {
+  persist,
+  createJSONStorage,
+  type PersistOptions,
+} from 'zustand/middleware';
 
 interface SettingsState {
   hasInteracted: boolean;
@@ -12,43 +17,65 @@ interface SettingsState {
   setVolume: (volume: number) => void;
 }
 
-export const useSettingsStore = create<SettingsState>((set, get) => ({
-  hasInteracted: false,
-  queue: [],
-  audios: [],
-  soundEnabled: true,
-  volume: 1,
-  markInteracted: () => {
-    if (get().hasInteracted) return;
-    const queued = get().queue;
-    set({ hasInteracted: true, queue: [] });
-    for (const audio of queued) {
-      // Attempt to play; ignore errors (e.g. autoplay restrictions)
-      audio.play().catch(() => {});
-    }
-  },
-  enqueueAudio: (audio: HTMLAudioElement) => {
-    audio.volume = get().volume;
-    audio.muted = !get().soundEnabled;
-    set((s) => ({ audios: [...s.audios, audio] }));
-    if (get().hasInteracted) {
-      audio.play().catch(() => {});
-    } else {
-      set((s) => ({ queue: [...s.queue, audio] }));
-    }
-  },
-  setSoundEnabled: (enabled: boolean) => {
-    set({ soundEnabled: enabled });
-    const audios = get().audios;
-    for (const audio of audios) {
-      audio.muted = !enabled;
-    }
-  },
-  setVolume: (volume: number) => {
-    set({ volume });
-    const audios = get().audios;
-    for (const audio of audios) {
-      audio.volume = volume;
-    }
-  },
-}));
+type PersistedSettings = { soundEnabled: boolean; volume: number };
+
+export const useSettingsStore = create<SettingsState>()(
+  persist(
+    (set, get) => ({
+      hasInteracted: false,
+      queue: [],
+      audios: [],
+      soundEnabled: true,
+      volume: 1,
+      markInteracted: () => {
+        if (get().hasInteracted) return;
+        const queued = get().queue;
+        set({ hasInteracted: true, queue: [] });
+        for (const audio of queued) {
+          // Attempt to play; ignore errors (e.g. autoplay restrictions)
+          audio.play().catch(() => {});
+        }
+      },
+      enqueueAudio: (audio: HTMLAudioElement) => {
+        audio.volume = get().volume;
+        audio.muted = !get().soundEnabled;
+        set((s) => ({ audios: [...s.audios, audio] }));
+        if (get().hasInteracted) {
+          audio.play().catch(() => {});
+        } else {
+          set((s) => ({ queue: [...s.queue, audio] }));
+        }
+      },
+      setSoundEnabled: (enabled: boolean) => {
+        set({ soundEnabled: enabled });
+        const audios = get().audios;
+        for (const audio of audios) {
+          audio.muted = !enabled;
+        }
+      },
+      setVolume: (volume: number) => {
+        set({ volume });
+        const audios = get().audios;
+        for (const audio of audios) {
+          audio.volume = volume;
+        }
+      },
+    }),
+    {
+      name: 'settings',
+      version: 1,
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({
+        soundEnabled: state.soundEnabled,
+        volume: state.volume,
+      }),
+      onRehydrateStorage: () => (state) => {
+        if (!state) return;
+        for (const audio of state.audios) {
+          audio.muted = !state.soundEnabled;
+          audio.volume = state.volume;
+        }
+      },
+    } as PersistOptions<SettingsState, PersistedSettings>,
+  ),
+);

--- a/src/tests/audioInteraction.test.ts
+++ b/src/tests/audioInteraction.test.ts
@@ -3,6 +3,7 @@ import { useSettingsStore } from '../app/settingsStore';
 
 describe('audio interaction gating', () => {
   beforeEach(() => {
+    useSettingsStore.persist.clearStorage();
     useSettingsStore.setState({
       hasInteracted: false,
       queue: [],

--- a/src/tests/settingsPersistence.test.ts
+++ b/src/tests/settingsPersistence.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useSettingsStore } from '../app/settingsStore';
+
+describe('settings persistence', () => {
+  beforeEach(() => {
+    useSettingsStore.persist.clearStorage();
+    useSettingsStore.setState({
+      hasInteracted: false,
+      queue: [],
+      audios: [],
+      soundEnabled: true,
+      volume: 1,
+    });
+  });
+
+  it('persists sound settings to localStorage', () => {
+    useSettingsStore.getState().setSoundEnabled(false);
+    useSettingsStore.getState().setVolume(0.5);
+    const raw = localStorage.getItem('settings');
+    expect(raw).not.toBeNull();
+    const data = JSON.parse(raw!);
+    expect(data.state.soundEnabled).toBe(false);
+    expect(data.state.volume).toBeCloseTo(0.5);
+  });
+
+  it('rehydrates sound settings from localStorage', async () => {
+    const payload = { state: { soundEnabled: false, volume: 0.5 }, version: 1 };
+    localStorage.setItem('settings', JSON.stringify(payload));
+    await useSettingsStore.persist.rehydrate();
+    const state = useSettingsStore.getState();
+    expect(state.soundEnabled).toBe(false);
+    expect(state.volume).toBeCloseTo(0.5);
+  });
+});


### PR DESCRIPTION
## Summary
- Persist sound enabled and volume via Zustand and localStorage
- Ensure stored values are applied to audio elements after rehydration
- Add tests covering audio interaction gating and settings persistence

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c40fe7a1308328a44e6fbbf413c190