### PR TITLE
Fix progression reset on major version change

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -188,7 +188,7 @@ export const useGameStore = create<State>()(
         const s = get();
         set({
           ...initialState,
-          eraMult: s.eraMult + 10,
+          eraMult: s.eraMult + 1,
         });
         get().recompute();
         saveGame();
@@ -299,15 +299,21 @@ export const useGameStore = create<State>()(
         state.recompute();
         const delta = (now - last) / 1000;
         state.tick(delta);
-        state.lastSave = now;
+        saveGame();
         if (needsEraPrompt) {
-          const next = state.eraMult + 10;
+          const next = state.eraMult + 1;
           const isJsDom =
             typeof navigator !== 'undefined' && navigator.userAgent.includes('jsdom');
           if (!isJsDom) {
             if (
               confirm(
-                `Suomen sauna maailma on muuttunut täysin, haluatko polttaa koko maailman, ja aloittaa alusta?\nUudessa maailmassa saat ${next}× bonuksen lämpötilaan!\n\nOK: Haluan nähdä kun maailma palaa\nCancel: Haluan jatkaa nykyisillä`,
+                [
+                  'Suomen sauna maailma on muuttunut täysin, haluatko polttaa koko maailman, ja aloittaa alusta?',
+                  `Uudessa maailmassa saat ${next}× bonuksen lämpötilaan!`,
+                  '',
+                  'OK: Haluan nähdä kun maailma palaa',
+                  'Cancel: Haluan jatkaa nykyisillä',
+                ].join('\n'),
               )
             ) {
               state.changeEra();

--- a/src/tests/prestige.test.ts
+++ b/src/tests/prestige.test.ts
@@ -68,6 +68,13 @@ describe('polta sauna', () => {
     expect(s.totalPopulation).toBe(0);
     expect(s.prestigePoints).toBe(0);
     expect(s.prestigeMult).toBe(1);
-    expect(s.eraMult).toBe(11);
+    expect(s.eraMult).toBe(2);
+  });
+
+  it('era multiplier stacks additively', () => {
+    useGameStore.getState().changeEra();
+    useGameStore.getState().changeEra();
+    const s = useGameStore.getState();
+    expect(s.eraMult).toBe(3);
   });
 });


### PR DESCRIPTION
## Summary
- Persist rehydrated state before showing the era-reset prompt to ensure accepting the dialog wipes prior progress
- Clean up era-reset dialog string and avoid direct state mutation
- Set era reset bonus to a flat 2× and stack additively with other era multipliers
- Update tests for era reset behavior and additive stacking

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c414641ce48328b2d7b88d689fb2ec