### PR TITLE
Persist last save timestamp on rehydrate

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -299,7 +299,7 @@ export const useGameStore = create<State>()(
         state.recompute();
         const delta = (now - last) / 1000;
         state.tick(delta);
-        state.lastSave = now;
+        useGameStore.setState({ lastSave: now });
         if (needsEraPrompt) {
           const next = state.eraMult + 10;
           const isJsDom =

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -165,16 +165,17 @@ describe('model v5', () => {
         clickPower: 1,
         prestigePoints: 0,
         prestigeMult: 1,
+        eraMult: 1,
         lastSave: fiveSecondsAgo,
       },
-      version: 3,
+      version: BigBeautifulBalancePath,
     };
     localStorage.setItem('suomidle', JSON.stringify(payload));
     await useGameStore.persist.rehydrate();
     const first = useGameStore.getState().population;
     await useGameStore.persist.rehydrate();
     const second = useGameStore.getState().population;
-    expect(first).toBeCloseTo(110, 0);
-    expect(second).toBeCloseTo(first, 0);
+    expect(first).toBeCloseTo(150);
+    expect(second).toBeCloseTo(first);
   });
 });


### PR DESCRIPTION
## Summary
- Persist last save timestamp when rehydrating game store
- Test that offline gains aren't reapplied on rapid rehydration

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c417b8748c8328a71b66746030349e