### PR TITLE
Fix offline progress rounding after rehydrate

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -297,9 +297,9 @@ export const useGameStore = create<State>()(
         const now = Date.now();
         const last = state.lastSave ?? now;
         state.recompute();
-        const delta = (now - last) / 1000;
+        const delta = Math.max(0, Math.floor((now - last) / 1000));
         state.tick(delta);
-        saveGame();
+        useGameStore.setState({ lastSave: now });
         if (needsEraPrompt) {
           const next = state.eraMult + 1;
           const isJsDom =


### PR DESCRIPTION
## Summary
- Floor offline time to whole seconds during rehydrate and persist the new timestamp via setState

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4193174548328930f025ddd23948d