### PR TITLE
Scale clicks with LPS

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -36,4 +36,12 @@ describe('HUD', () => {
     render(<HUD />);
     expect(screen.getByText(/LPS: 5/)).toBeInTheDocument();
   });
+
+  it('click gains at least 1% of cps, rounded', () => {
+    useGameStore.setState({ buildings: { sauna: 250 } });
+    useGameStore.getState().recompute();
+    render(<HUD />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(useGameStore.getState().population).toBe(3);
+  });
 });

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -136,7 +136,8 @@ export const useGameStore = create<State>()(
           cps += b.baseProd * count;
         }
         cps *= s.prestigeMult * s.multipliers.population_cps * s.eraMult;
-        set({ cps });
+        const clickPower = Math.max(1, Math.round(cps / 100));
+        set({ cps, clickPower });
       },
       tick: (delta) => {
         const gain = get().cps * delta;


### PR DESCRIPTION
## Summary
- ensure click power matches at least 1% of current LPS
- cover click scaling with new component test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c41b19432883289af7d79262bfc16a