### PR TITLE
feat: add basic sauna entity and ui

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { useGameStore } from './app/store';
 import './App.css';
 import { playTierMusic } from './audio/music';
 import { useSettingsStore } from './app/settingsStore';
+import { Sauna } from './ui/sauna';
 
 function App() {
   const tierLevel = useGameStore((s) => s.tierLevel);
@@ -51,6 +52,7 @@ function App() {
           Tap to start
         </div>
       )}
+      <Sauna />
       <Settings />
       <HUD />
       <PrestigeCard />

--- a/src/app/gameLoop.ts
+++ b/src/app/gameLoop.ts
@@ -1,4 +1,5 @@
 import { useGameStore, saveGame } from './store';
+import { useSaunaStore } from '../sim/sauna';
 
 let last = 0;
 let sinceSave = 0;
@@ -12,6 +13,7 @@ export function startGameLoop() {
     const delta = (now - last) / 1000;
     last = now;
     useGameStore.getState().tick(delta);
+    useSaunaStore.getState().tick(delta);
     sinceSave += delta;
     if (sinceSave >= 5) {
       saveGame();

--- a/src/sim/sauna.ts
+++ b/src/sim/sauna.ts
@@ -1,0 +1,44 @@
+import { create } from 'zustand';
+
+export interface Sauna {
+  id: 'sauna';
+  pos: { q: number; r: number };
+  spawnCooldown: number;
+  timer: number;
+  auraRadius: number;
+  regenPerSec: number;
+  rally: boolean;
+}
+
+const defaultSauna: Sauna = {
+  id: 'sauna',
+  pos: { q: 0, r: 0 },
+  spawnCooldown: 30,
+  timer: 30,
+  auraRadius: 2,
+  regenPerSec: 1,
+  rally: false,
+};
+
+interface SaunaState {
+  sauna: Sauna;
+  toggleRally: () => void;
+  tick: (dt: number) => void;
+}
+
+export const useSaunaStore = create<SaunaState>()((set) => ({
+  sauna: defaultSauna,
+  toggleRally: () =>
+    set((s) => ({ sauna: { ...s.sauna, rally: !s.sauna.rally } })),
+  tick: (dt) =>
+    set((s) => {
+      const sauna = { ...s.sauna };
+      sauna.timer -= dt;
+      if (sauna.timer <= 0) {
+        sauna.timer += sauna.spawnCooldown;
+        // TODO: integrate with unit spawning logic
+        console.log('Spawn Raider near sauna');
+      }
+      return { sauna };
+    }),
+}));

--- a/src/ui/sauna.tsx
+++ b/src/ui/sauna.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import { useSaunaStore } from '../sim/sauna';
+
+export function Sauna() {
+  const sauna = useSaunaStore((s) => s.sauna);
+  const toggleRally = useSaunaStore((s) => s.toggleRally);
+  const [open, setOpen] = useState(false);
+  const seconds = Math.ceil(sauna.timer);
+  return (
+    <>
+      <div
+        style={{ position: 'absolute', top: 8, left: 8, cursor: 'pointer' }}
+        onClick={() => setOpen((o) => !o)}
+      >
+        Sauna ♨️
+      </div>
+      {open && (
+        <div
+          style={{
+            position: 'absolute',
+            top: 40,
+            left: 8,
+            padding: 8,
+            border: '1px solid #ccc',
+            background: '#fff',
+            color: '#000',
+          }}
+        >
+          <h3>Sauna</h3>
+          <div>Next in 00:{seconds.toString().padStart(2, '0')}</div>
+          <label>
+            <input type="checkbox" checked={sauna.rally} onChange={toggleRally} />
+            Rally to Front
+          </label>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- create Sauna state store with timer and rally flag
- render clickable Sauna overlay card
- tick Sauna timer in main game loop

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6ec85375c8330b446e161d26092c4