### PR TITLE
Add schema definitions for Maailma save data

### DIFF
--- a/src/state/schema.ts
+++ b/src/state/schema.ts
@@ -1,0 +1,44 @@
+export type DecimalString = `${number}`;
+
+export interface MaailmaPurchase {
+  /** Identifier of the Maailma shop item. */
+  id: string;
+  /** Current level purchased for the item. */
+  level: number;
+}
+
+export interface MaailmaState {
+  /** Available Tuhka currency represented as a decimal string. */
+  tuhka: DecimalString;
+  /** Total Tuhka earned over the lifetime of the save, as a decimal string. */
+  totalTuhkaEarned: DecimalString;
+  /** Mapping of Maailma purchase id to its purchase details. */
+  purchases: Record<string, MaailmaPurchase>;
+}
+
+export interface MultipliersState {
+  population_cps: number;
+}
+
+export interface GameState {
+  population: number;
+  totalPopulation: number;
+  tierLevel: number;
+  buildings: Record<string, number>;
+  techCounts: Record<string, number>;
+  multipliers: MultipliersState;
+  cps: number;
+  clickPower: number;
+  prestigePoints: number;
+  prestigeMult: number;
+  eraMult: number;
+  lastSave: number;
+  lastMajorVersion: number;
+  eraPromptAcknowledged: boolean;
+  maailma: MaailmaState;
+}
+
+export interface SaveGame {
+  version: number;
+  state: GameState;
+}


### PR DESCRIPTION
## Summary
- define MaailmaPurchase and MaailmaState schema structures with decimal string tracking for tuhka values
- expose GameState and SaveGame interfaces that include the Maailma state block for persistence

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68c9536616e48328bd24cc3bc7ce32c1