### PR TITLE
Add Maailma state to persisted schema

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -198,6 +198,17 @@ const sanitizeState = (state: State): BaseState => {
     changeEra: _changeEra,
     ...rest
   } = state;
+  void _addPopulation;
+  void _purchaseBuilding;
+  void _purchaseTech;
+  void _recompute;
+  void _tick;
+  void _canAdvanceTier;
+  void _advanceTier;
+  void _canPrestige;
+  void _projectPrestigeGain;
+  void _prestige;
+  void _changeEra;
   const base = rest as BaseState;
   const maailma = normalizeMaailma(base.maailma);
   return { ...base, maailma };

--- a/src/state/schema.ts
+++ b/src/state/schema.ts
@@ -41,4 +41,5 @@ export interface GameState {
 export interface SaveGame {
   version: number;
   state: GameState;
+  maailma: MaailmaState;
 }


### PR DESCRIPTION
## Summary
- include the Maailma state in the save schema while keeping its currency fields typed as decimal strings
- mark destructured store actions as intentionally unused so eslint passes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9601c302c8328b70a2352c2c4c276