### PR TITLE
Add Maailma shop interface with purchases

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { useGameStore } from './app/store';
 import './App.css';
 import { playTierMusic } from './audio/music';
 import { useSettingsStore } from './app/settingsStore';
+import { MaailmaShop } from './ui/MaailmaShop';
 
 function App() {
   const tierLevel = useGameStore((s) => s.tierLevel);
@@ -57,6 +58,7 @@ function App() {
       <BuildingsGrid />
       <TechGrid />
       <Prestige />
+      <MaailmaShop />
     </>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -204,3 +204,257 @@ h1 {
     height: 2px;
   }
 }
+
+.maailma-shop {
+  position: relative;
+  margin: 2rem auto;
+  padding: 1.5rem;
+  max-width: min(960px, 95vw);
+  background: color-mix(in srgb, var(--surface-elevated) 92%, transparent);
+  border-radius: 1rem;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.25);
+  overflow: hidden;
+}
+
+.maailma-shop__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  position: relative;
+  z-index: 1;
+}
+
+.maailma-shop__title {
+  margin: 0;
+}
+
+.maailma-shop__balance {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface) 65%, transparent);
+  font-weight: 600;
+  font-size: 1.1rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.maailma-shop__balance-value {
+  font-weight: 700;
+}
+
+.maailma-shop__table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+  position: relative;
+  z-index: 1;
+}
+
+.maailma-shop__table th,
+.maailma-shop__table td {
+  padding: 0.75rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.maailma-shop__table th {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--color-text) 75%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-text) 18%, transparent);
+}
+
+.maailma-shop__row {
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.maailma-shop__row:nth-child(odd) {
+  background: color-mix(in srgb, var(--surface) 55%, transparent);
+}
+
+.maailma-shop__row:nth-child(even) {
+  background: color-mix(in srgb, var(--surface) 35%, transparent);
+}
+
+.maailma-shop__row:hover {
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--surface-elevated) 80%, transparent);
+}
+
+.maailma-shop__row--maxed {
+  opacity: 0.65;
+}
+
+.maailma-shop__item {
+  max-width: 420px;
+}
+
+.maailma-shop__name {
+  font-weight: 600;
+  font-size: 1.05rem;
+  margin-bottom: 0.25rem;
+}
+
+.maailma-shop__description {
+  font-size: 0.95rem;
+  line-height: 1.4;
+  opacity: 0.85;
+}
+
+.maailma-shop__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 0.45rem;
+  font-size: 0.75rem;
+  opacity: 0.85;
+}
+
+.maailma-shop__tooltip {
+  border-bottom: 1px dotted currentColor;
+  cursor: help;
+  padding-bottom: 1px;
+}
+
+.maailma-shop__level {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.25rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.maailma-shop__level-divider {
+  opacity: 0.65;
+}
+
+.maailma-shop__cost {
+  text-align: right;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.maailma-shop__currency {
+  font-size: 0.75rem;
+  font-weight: 500;
+  opacity: 0.8;
+}
+
+.maailma-shop__cost--maxed {
+  opacity: 0.6;
+}
+
+.maailma-shop__action,
+.maailma-shop__action-header {
+  text-align: center;
+}
+
+.maailma-shop__buy {
+  min-width: 120px;
+  box-shadow: 0 6px 18px rgba(255, 140, 0, 0.4);
+}
+
+.maailma-shop__buy:disabled {
+  opacity: 0.55;
+  box-shadow: none;
+  cursor: not-allowed;
+}
+
+.maailma-shop__embers {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.maailma-shop__ember {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 210, 150, 0.95) 0%, rgba(255, 132, 40, 0.8) 55%, rgba(255, 132, 40, 0) 100%);
+  box-shadow: 0 0 18px rgba(255, 160, 50, 0.75);
+  opacity: 0;
+  transform: translate(-50%, -50%) scale(1);
+  animation-name: maailma-shop-ember;
+  animation-fill-mode: forwards;
+  animation-timing-function: ease-out;
+  will-change: transform, opacity;
+  mix-blend-mode: screen;
+}
+
+@keyframes maailma-shop-ember {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(var(--maailma-ember-scale, 1));
+  }
+  20% {
+    opacity: 0.95;
+  }
+  100% {
+    opacity: 0;
+    transform: translate(
+        calc(-50% + var(--maailma-ember-drift, 0px)),
+        calc(-50% - var(--maailma-ember-rise, 56px))
+      )
+      scale(0.25);
+  }
+}
+
+@media (max-width: 960px) {
+  .maailma-shop {
+    padding: 1.25rem;
+  }
+}
+
+@media (max-width: 720px) {
+  .maailma-shop {
+    padding: 1rem;
+  }
+  .maailma-shop__table {
+    display: block;
+    overflow-x: auto;
+  }
+  .maailma-shop__table thead {
+    display: none;
+  }
+  .maailma-shop__table tbody {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .maailma-shop__row,
+  .maailma-shop__row:nth-child(even),
+  .maailma-shop__row:nth-child(odd) {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 1rem;
+    border-radius: 0.75rem;
+    background: color-mix(in srgb, var(--surface) 55%, transparent);
+  }
+  .maailma-shop__item,
+  .maailma-shop__level,
+  .maailma-shop__cost,
+  .maailma-shop__action {
+    text-align: left;
+  }
+  .maailma-shop__level {
+    justify-content: flex-start;
+  }
+  .maailma-shop__cost {
+    font-size: 1rem;
+  }
+  .maailma-shop__action {
+    margin-top: 0.25rem;
+  }
+  .maailma-shop__buy {
+    width: 100%;
+  }
+}

--- a/src/ui/MaailmaShop.tsx
+++ b/src/ui/MaailmaShop.tsx
@@ -1,0 +1,267 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type MouseEvent,
+} from 'react';
+import { useGameStore } from '../app/store';
+import shopData from '../data/maailma_shop.json' assert { type: 'json' };
+import { formatNumber } from '../utils/format';
+
+const { currency, shop: shopItems } = shopData;
+const currencyLabel = currency.short_fi ?? currency.name_fi;
+
+interface Ember {
+  id: number;
+  x: number;
+  y: number;
+  scale: number;
+  drift: number;
+  rise: number;
+  duration: number;
+}
+
+type EmberStyle = CSSProperties & {
+  '--maailma-ember-scale'?: string;
+  '--maailma-ember-rise'?: string;
+  '--maailma-ember-drift'?: string;
+};
+
+const STACK_MODE_LABELS = {
+  add: 'Additiivinen',
+  mult: 'Kertautuva',
+} as const;
+
+const STACK_MODE_TOOLTIPS = {
+  add: 'Bonukset summataan yhteen jokaisella tasolla.',
+  mult: 'Bonukset kertautuvat keskenään jokaisella tasolla.',
+} as const satisfies Record<keyof typeof STACK_MODE_LABELS, string>;
+
+const formatDecimalString = (value: number) => {
+  if (!Number.isFinite(value)) return '0';
+  const safe = Math.max(0, value);
+  const fixed = safe.toFixed(6);
+  const trimmed = fixed.replace(/\.0+$/, '').replace(/\.([0-9]*?)0+$/, '.$1');
+  const cleaned = trimmed.endsWith('.') ? trimmed.slice(0, -1) : trimmed;
+  return cleaned.length > 0 ? cleaned : '0';
+};
+
+const formatDecimalNumber = (value: number) =>
+  Number.isInteger(value) ? value.toString() : value.toFixed(2);
+
+const getNextCost = (item: (typeof shopItems)[number], level: number) => {
+  if (item.cost_tuhka.length === 0 || level >= item.max_level) {
+    return undefined;
+  }
+  const index = Math.min(level, item.cost_tuhka.length - 1);
+  return item.cost_tuhka[index];
+};
+
+export function MaailmaShop() {
+  const tuhkaString = useGameStore((state) => state.maailma.tuhka);
+  const purchaseHistory = useGameStore((state) => state.maailma.purchases);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [embers, setEmbers] = useState<Ember[]>([]);
+  const emberTimeouts = useRef<number[]>([]);
+
+  useEffect(() => () => {
+    emberTimeouts.current.forEach((timeoutId) => {
+      window.clearTimeout(timeoutId);
+    });
+    emberTimeouts.current = [];
+  }, []);
+
+  const tuhkaValue = useMemo(() => {
+    const numeric = Number.parseFloat(tuhkaString);
+    return Number.isFinite(numeric) ? numeric : 0;
+  }, [tuhkaString]);
+
+  const purchaseCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const id of purchaseHistory) {
+      counts.set(id, (counts.get(id) ?? 0) + 1);
+    }
+    return counts;
+  }, [purchaseHistory]);
+
+  const spawnEmber = (centerX: number, centerY: number) => {
+    const container = containerRef.current;
+    if (!container) return;
+    const rect = container.getBoundingClientRect();
+    const ember: Ember = {
+      id: Date.now() + Math.random(),
+      x: centerX - rect.left,
+      y: centerY - rect.top,
+      scale: 0.85 + Math.random() * 0.4,
+      drift: (Math.random() - 0.5) * 40,
+      rise: 48 + Math.random() * 36,
+      duration: 750 + Math.random() * 450,
+    };
+    setEmbers((prev) => [...prev, ember]);
+    const timeoutId = window.setTimeout(() => {
+      setEmbers((prev) => prev.filter((item) => item.id !== ember.id));
+      emberTimeouts.current = emberTimeouts.current.filter((id) => id !== timeoutId);
+    }, ember.duration);
+    emberTimeouts.current.push(timeoutId);
+  };
+
+  const attemptPurchase = (event: MouseEvent<HTMLButtonElement>, item: (typeof shopItems)[number]) => {
+    const buttonRect = event.currentTarget.getBoundingClientRect();
+    const centerX = buttonRect.left + buttonRect.width / 2;
+    const centerY = buttonRect.top + buttonRect.height / 2;
+
+    let purchased = false;
+    useGameStore.setState((state) => {
+      const { maailma } = state;
+      const numericTuhka = Number.parseFloat(maailma.tuhka);
+      if (!Number.isFinite(numericTuhka)) return {};
+      const level = maailma.purchases.filter((id) => id === item.id).length;
+      if (level >= item.max_level) return {};
+      const nextCost = getNextCost(item, level);
+      if (nextCost === undefined || numericTuhka < nextCost) return {};
+      purchased = true;
+      return {
+        maailma: {
+          ...maailma,
+          tuhka: formatDecimalString(numericTuhka - nextCost),
+          purchases: [...maailma.purchases, item.id],
+        },
+      };
+    });
+
+    if (purchased) {
+      spawnEmber(centerX, centerY);
+    }
+  };
+
+  return (
+    <div className="maailma-shop" ref={containerRef}>
+      <div className="maailma-shop__header">
+        <h2 className="maailma-shop__title text--h2">Maailman kauppa</h2>
+        <div
+          className="maailma-shop__balance"
+          title={currency.accrual_formula_fi || undefined}
+        >
+          {currencyLabel}:&nbsp;
+          <span className="maailma-shop__balance-value">{formatNumber(tuhkaValue)}</span>
+        </div>
+      </div>
+      <table className="maailma-shop__table">
+        <thead>
+          <tr>
+            <th scope="col">Parannus</th>
+            <th scope="col">Taso</th>
+            <th scope="col">Seuraava hinta</th>
+            <th scope="col" className="maailma-shop__action-header">
+              Toiminto
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {shopItems.map((item) => {
+            const level = purchaseCounts.get(item.id) ?? 0;
+            const nextCost = getNextCost(item, level);
+            const maxed = level >= item.max_level;
+            const affordable = nextCost !== undefined && tuhkaValue >= nextCost;
+            const disabled = maxed || !affordable;
+            const stackMode = item.effect.stack_mode;
+            const stackLabel =
+              stackMode === 'add'
+                ? STACK_MODE_LABELS.add
+                : stackMode === 'mult'
+                  ? STACK_MODE_LABELS.mult
+                  : undefined;
+            const stackTooltip =
+              stackMode === 'add'
+                ? STACK_MODE_TOOLTIPS.add
+                : stackMode === 'mult'
+                  ? STACK_MODE_TOOLTIPS.mult
+                  : undefined;
+            const floorValue =
+              typeof item.effect.floor === 'number' ? item.effect.floor : undefined;
+            const buttonTitle = maxed
+              ? 'Maksimitaso saavutettu'
+              : affordable
+                ? 'Osta seuraava taso'
+                : 'Ei tarpeeksi Tuhkaa';
+
+            return (
+              <tr
+                key={item.id}
+                className={`maailma-shop__row${maxed ? ' maailma-shop__row--maxed' : ''}`}
+              >
+                <td className="maailma-shop__item">
+                  <div className="maailma-shop__name">{item.name_fi}</div>
+                  <div className="maailma-shop__description">{item.description_fi}</div>
+                  {(stackLabel || floorValue !== undefined) && (
+                    <div className="maailma-shop__meta">
+                      {stackLabel && (
+                        <span className="maailma-shop__tooltip" title={stackTooltip}>
+                          Pinoutuminen: {stackLabel}
+                        </span>
+                      )}
+                      {floorValue !== undefined && (
+                        <span
+                          className="maailma-shop__tooltip"
+                          title={`Vaikutus ei voi laskea arvoa alle ${formatDecimalNumber(floorValue)}.`}
+                        >
+                          Lattia: {formatDecimalNumber(floorValue)}
+                        </span>
+                      )}
+                    </div>
+                  )}
+                </td>
+                <td className="maailma-shop__level">
+                  <span className="maailma-shop__level-current">{level}</span>
+                  <span className="maailma-shop__level-divider">/</span>
+                  <span className="maailma-shop__level-max">{item.max_level}</span>
+                </td>
+                <td className="maailma-shop__cost">
+                  {nextCost !== undefined ? (
+                    <>
+                      {formatNumber(nextCost)}
+                      <span className="maailma-shop__currency"> {currencyLabel}</span>
+                    </>
+                  ) : (
+                    <span className="maailma-shop__cost--maxed">—</span>
+                  )}
+                </td>
+                <td className="maailma-shop__action">
+                  <button
+                    type="button"
+                    className="btn btn--primary maailma-shop__buy"
+                    disabled={disabled}
+                    title={buttonTitle}
+                    onClick={(event) => attemptPurchase(event, item)}
+                  >
+                    {maxed ? 'Maksimi' : 'Osta'}
+                  </button>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      <div className="maailma-shop__embers" aria-hidden="true">
+        {embers.map((ember) => (
+          <span
+            key={ember.id}
+            className="maailma-shop__ember"
+            style={
+              {
+                left: `${ember.x}px`,
+                top: `${ember.y}px`,
+                animationDuration: `${ember.duration}ms`,
+                '--maailma-ember-scale': `${ember.scale}`,
+                '--maailma-ember-rise': `${ember.rise}px`,
+                '--maailma-ember-drift': `${ember.drift}px`,
+              } as EmberStyle
+            }
+          />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a MaailmaShop UI component that reads maailma_shop.json to render Tuhka balance, upgrade rows, and purchase flow with tooltips and ember feedback
- integrate the MaailmaShop into the app shell and style the layout, table, and animated ember effect

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9604fc1088328a312f1b487a8d733