### PR TITLE
Add telemetry instrumentation for Maailma actions

### DIFF
--- a/src/state/schema.ts
+++ b/src/state/schema.ts
@@ -14,6 +14,8 @@ export interface MaailmaState {
   totalTuhkaEarned: DecimalString;
   /** Mapping of Maailma purchase id to its purchase details. */
   purchases: Record<string, MaailmaPurchase>;
+  /** Lifetime count of Maailma resets performed. */
+  totalResets?: number;
 }
 
 export interface MultipliersState {

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,0 +1,54 @@
+export type TelemetryEvent = string;
+
+export type TelemetryPayload = Record<string, unknown>;
+
+export interface TelemetryClient {
+  emit: (event: TelemetryEvent, payload: TelemetryPayload) => void;
+}
+
+const fallbackClient: TelemetryClient = {
+  emit: () => {},
+};
+
+let overrideClient: TelemetryClient | null = null;
+
+const candidateKeys = [
+  '__suomidleTelemetry',
+  'suomidleTelemetry',
+  '__telemetry',
+  'telemetry',
+] as const;
+
+const isTelemetryClient = (value: unknown): value is TelemetryClient =>
+  typeof value === 'object' &&
+  value !== null &&
+  'emit' in value &&
+  typeof (value as { emit?: unknown }).emit === 'function';
+
+const findGlobalTelemetryClient = (): TelemetryClient | null => {
+  const globalAny = globalThis as Record<string, unknown>;
+  for (const key of candidateKeys) {
+    const candidate = globalAny[key];
+    if (isTelemetryClient(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+};
+
+const resolveClient = (): TelemetryClient =>
+  overrideClient ?? findGlobalTelemetryClient() ?? fallbackClient;
+
+export const telemetry = {
+  emit(event: TelemetryEvent, payload: TelemetryPayload) {
+    try {
+      resolveClient().emit(event, payload);
+    } catch {
+      // Swallow telemetry errors to avoid impacting gameplay.
+    }
+  },
+};
+
+export const setTelemetryClient = (client: TelemetryClient | null) => {
+  overrideClient = client;
+};


### PR DESCRIPTION
## Summary
- add a telemetry helper that forwards events to the existing global client
- emit `polta_maailma` telemetry with reset context including purchases and total resets
- emit `maailma_purchase` telemetry events with cost and remaining currency, covered by tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9bf05e1c88328ad42d3bbb9095388