### PR TITLE
Adjust Maailma reset flow to preserve era multiplier

### DIFF
--- a/src/tests/prestige.test.ts
+++ b/src/tests/prestige.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { useGameStore, computePrestigePoints, computePrestigeMult } from '../app/store';
+import {
+  useGameStore,
+  computePrestigePoints,
+  computePrestigeMult,
+  poltaMaailmaConfirm,
+} from '../app/store';
 
 describe('polta sauna', () => {
   beforeEach(() => {
@@ -16,6 +21,13 @@ describe('polta sauna', () => {
       prestigePoints: 0,
       prestigeMult: 1,
       eraMult: 1,
+      maailma: {
+        tuhka: '0',
+        purchases: [],
+        totalTuhkaEarned: '0',
+        totalResets: 0,
+        era: 0,
+      },
     });
     useGameStore.getState().recompute();
   });
@@ -76,5 +88,42 @@ describe('polta sauna', () => {
     useGameStore.getState().changeEra();
     const s = useGameStore.getState();
     expect(s.eraMult).toBe(3);
+  });
+
+  it('polta maailma keeps era multiplier but clears progress', () => {
+    useGameStore.setState({
+      population: 12345,
+      totalPopulation: 987654,
+      tierLevel: 5,
+      buildings: { sauna: 3 },
+      techCounts: { vihta: 2 },
+      multipliers: { population_cps: 2 },
+      cps: 50,
+      prestigePoints: 4,
+      prestigeMult: 2.5,
+      eraMult: 3,
+      maailma: {
+        tuhka: '10',
+        purchases: [],
+        totalTuhkaEarned: '10',
+        totalResets: 0,
+        era: 0,
+      },
+    });
+
+    const result = poltaMaailmaConfirm();
+    const s = useGameStore.getState();
+
+    expect(result.awarded > 0n).toBe(true);
+    expect(s.population).toBe(0);
+    expect(s.totalPopulation).toBe(0);
+    expect(s.tierLevel).toBe(1);
+    expect(s.buildings.sauna).toBeUndefined();
+    expect(Object.keys(s.techCounts)).toHaveLength(0);
+    expect(s.prestigeMult).toBe(1);
+    expect(s.eraMult).toBe(3);
+    expect(s.maailma.tuhka).toBe(result.availableTuhka.toString());
+    expect(s.maailma.totalTuhkaEarned).toBe(result.totalTuhkaEarned.toString());
+    expect(s.maailma.totalResets).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- add a reusable progress reset helper that preserves the current era multiplier while wiping progress
- update poltaMaailmaConfirm to reuse the helper, reapply permanent bonuses, and persist without granting an extra era multiplier
- extend prestige tests to confirm burning the world resets progress but keeps the era multiplier intact

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca6492ffd08328aefb097c9791d702