### PR TITLE
Align Tuhka award preview with prestige multiplier

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,3 +1,4 @@
+import Decimal from 'decimal.js';
 import { create } from 'zustand';
 import {
   persist,
@@ -70,6 +71,7 @@ interface Actions {
 type State = BaseState & Actions;
 
 const STORAGE_KEY = 'suomidle';
+const decimalZero = new Decimal(0);
 
 const createInitialMaailmaState = (): MaailmaState => ({
   tuhka: '0',
@@ -624,19 +626,30 @@ export interface TuhkaAwardPreview {
 
 export const getTuhkaAwardPreview = (): TuhkaAwardPreview => {
   const state = useGameStore.getState();
-  const tierLevel = Math.max(1, state.tierLevel);
-  const totalPopulation = Math.max(0, state.totalPopulation);
-  const eraMult = Math.max(1, state.eraMult);
-  const totalResets = getSafeCount(state.maailma.totalResets);
   const current = toBigInt(state.maailma.tuhka);
   const totalEarned = toBigInt(state.maailma.totalTuhkaEarned);
+  const rawTier = new Decimal(state.tierLevel ?? 0);
+  const tier = rawTier.isFinite() ? Decimal.max(rawTier, decimalZero) : decimalZero;
+  const rawMultiplier = new Decimal(state.prestigeMult ?? 0);
+  const multiplier = rawMultiplier.isFinite()
+    ? Decimal.max(rawMultiplier, decimalZero)
+    : decimalZero;
 
-  const tierFactor = tierLevel + Math.log10(totalPopulation + 10);
-  const resetsFactor = Math.log10(totalResets + 10) + Math.log10(eraMult + 1);
-  const rawAward = Number.isFinite(tierFactor) && Number.isFinite(resetsFactor)
-    ? Math.sqrt(Math.max(0, tierFactor * resetsFactor))
-    : 0;
-  const award = BigInt(Math.max(0, Math.floor(rawAward)));
+  let awardDecimal = decimalZero;
+  if (tier.gt(0)) {
+    const logTerm = Decimal.log10(multiplier.plus(1));
+    if (logTerm.isFinite() && logTerm.gt(0)) {
+      const product = tier.mul(logTerm);
+      if (product.isFinite() && product.gt(0)) {
+        awardDecimal = product.sqrt().floor();
+      }
+    }
+  }
+
+  const award =
+    awardDecimal.isFinite() && awardDecimal.gte(0)
+      ? BigInt(awardDecimal.toFixed(0))
+      : 0n;
 
   return {
     current,

--- a/src/systems/maailma.ts
+++ b/src/systems/maailma.ts
@@ -182,12 +182,21 @@ const updateTuhkaTotals = (maailma: MaailmaState, award: Decimal): MaailmaState 
 };
 
 export const getTuhkaAwardPreview = (state: GameState): Decimal => {
-  const tier = decimalFrom(state.tierLevel ?? 0);
-  const multiplier = decimalFrom(state.prestigeMult ?? 0);
-  if (tier.lte(0) || multiplier.lte(0)) return zero;
-  const logTerm = multiplier.plus(1).log();
+  const rawTier = decimalFrom(state.tierLevel ?? 0);
+  const tier = rawTier.isFinite() ? Decimal.max(rawTier, zero) : zero;
+  const rawMultiplier = decimalFrom(state.prestigeMult ?? 0);
+  const multiplier = rawMultiplier.isFinite()
+    ? Decimal.max(rawMultiplier, zero)
+    : zero;
+  if (tier.lte(0)) return zero;
+
+  const logTerm = Decimal.log10(multiplier.plus(1));
   if (!logTerm.isFinite() || logTerm.lte(0)) return zero;
-  return tier.mul(logTerm).sqrt().floor();
+
+  const product = tier.mul(logTerm);
+  if (!product.isFinite() || product.lte(0)) return zero;
+
+  return product.sqrt().floor();
 };
 
 export const canPoltaMaailma = (state: GameState): boolean =>

--- a/src/ui/PoltaMaailmaButton.tsx
+++ b/src/ui/PoltaMaailmaButton.tsx
@@ -28,21 +28,17 @@ export function PoltaMaailmaButton() {
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   const tierLevel = useGameStore((s) => s.tierLevel);
-  const eraMult = useGameStore((s) => s.eraMult);
-  const totalPopulation = useGameStore((s) => s.totalPopulation);
+  const prestigeMult = useGameStore((s) => s.prestigeMult);
   const tuhka = useGameStore((s) => s.maailma.tuhka);
   const totalTuhkaEarned = useGameStore((s) => s.maailma.totalTuhkaEarned);
-  const totalResets = useGameStore((s) => s.maailma.totalResets);
 
   const preview: TuhkaAwardPreview = useMemo(() => {
     void tierLevel;
-    void eraMult;
-    void totalPopulation;
+    void prestigeMult;
     void tuhka;
     void totalTuhkaEarned;
-    void totalResets;
     return getTuhkaAwardPreview();
-  }, [tierLevel, eraMult, totalPopulation, tuhka, totalTuhkaEarned, totalResets]);
+  }, [tierLevel, prestigeMult, tuhka, totalTuhkaEarned]);
 
   const showToast = (message: string) => {
     setToastMessage(message);


### PR DESCRIPTION
## Summary
- compute Tuhka award previews with Decimal-based sqrt(tier * log10(multiplier + 1)) using the prestige multiplier from state
- mirror the same prestige-multiplier formula in the maailma system logic
- refresh the PoltaMaailmaButton preview memo to react to prestige multiplier changes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca648324fc83289bc01605009ba982