### PR TITLE
Reapply permanent Maailma bonuses after reset

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -199,10 +199,17 @@ const createInitialBaseState = (): BaseState => {
 
 const createProgressResetState = (state: State, maailmaOverride?: MaailmaState): BaseState => {
   const base = createInitialBaseState();
+  const maailma = normalizeMaailma(maailmaOverride ?? state.maailma);
+  const permanent = computePermanentBonusesFromMaailma(maailma);
+  const prestigeMult = Math.max(base.prestigeMult, permanent.saunaPrestigeBaseMultiplierMin);
+  const lampotilaRate = Math.max(0, permanent.lampotilaRateMult);
   return {
     ...base,
     eraMult: state.eraMult,
-    maailma: normalizeMaailma(maailmaOverride ?? state.maailma),
+    maailma,
+    modifiers: { ...(base.modifiers ?? { permanent }), permanent },
+    prestigeMult,
+    lampotilaRate,
   };
 };
 

--- a/src/tests/prestige.test.ts
+++ b/src/tests/prestige.test.ts
@@ -126,4 +126,36 @@ describe('polta sauna', () => {
     expect(s.maailma.totalTuhkaEarned).toBe(result.totalTuhkaEarned.toString());
     expect(s.maailma.totalResets).toBe(1);
   });
+
+  it('polta maailma reapplies permanent bonuses after reset', () => {
+    const initialMaailma = useGameStore.getState().maailma;
+    useGameStore.setState({
+      prestigePoints: 9,
+      prestigeMult: 3.5,
+      maailma: {
+        ...initialMaailma,
+        tuhka: '200',
+        purchases: [],
+        totalTuhkaEarned: '200',
+        totalResets: 0,
+        era: 0,
+      },
+    });
+
+    expect(useGameStore.getState().purchaseMaailmaUpgrade('feeniks_sauna')).toBe(true);
+    expect(useGameStore.getState().purchaseMaailmaUpgrade('alkulampo')).toBe(true);
+
+    useGameStore.setState({ prestigePoints: 12, prestigeMult: 5 });
+
+    poltaMaailmaConfirm();
+    const s = useGameStore.getState();
+
+    expect(s.prestigePoints).toBe(0);
+    expect(s.prestigeMult).toBeCloseTo(2);
+    expect(s.modifiers.permanent.saunaPrestigeBaseMultiplierMin).toBeCloseTo(2);
+    expect(s.lampotilaRate).toBeCloseTo(1.05);
+    expect(s.modifiers.permanent.lampotilaRateMult).toBeCloseTo(1.05);
+    expect(s.maailma.purchases.filter((id) => id === 'feeniks_sauna')).toHaveLength(1);
+    expect(s.maailma.purchases.filter((id) => id === 'alkulampo')).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## Summary
- recompute permanent Maailma bonuses during world resets so modifiers, prestige multiplier, and lämpötila rate persist
- add a regression test that buys Maailma upgrades, burns the world, and checks that permanent bonuses carry over

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cab1502fc08328b16117c5f1c6ce4a