### PR TITLE
Add daily task system with events and persistence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "suomidle",
       "version": "0.0.0",
       "dependencies": {
+        "luxon": "^3.5.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "zustand": "^5.0.0"
@@ -3247,6 +3248,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "vitest --run"
   },
   "dependencies": {
+    "luxon": "^3.5.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "zustand": "^5.0.0"

--- a/src/app/dailyTasks.ts
+++ b/src/app/dailyTasks.ts
@@ -1,0 +1,761 @@
+import { DateTime } from 'luxon';
+import { dailyTasks as rawDailyTasks } from '../content';
+import type { GameEventMap, GameEventType } from './events';
+
+export interface DailyTaskRewardTemplate {
+  type: 'temp_gain_mult';
+  value: number;
+  duration_s: number;
+  cooldown_s: number;
+}
+
+export type DailyTaskCondition =
+  | { type: 'counter'; event: keyof GameEventMap; target: number }
+  | { type: 'threshold'; metric: 'temperature'; target: number | string }
+  | { type: 'delta_threshold'; metric: 'prestige_multiplier' | 'population_earned_today'; target?: number | string; delta?: number }
+  | { type: 'streak'; event: keyof GameEventMap; window_s: number; max_gap_s: number }
+  | { type: 'streak_rate'; event: keyof GameEventMap; count: number; max_interval_s: number }
+  | { type: 'uptime'; target_s: number };
+
+export interface DailyTaskDefinition {
+  id: string;
+  title_fi: string;
+  desc_fi: string;
+  category: string;
+  condition: DailyTaskCondition;
+  reward: string;
+  weight: number;
+  min_tier: number;
+  max_per_day: number;
+  requires_feature?: string;
+}
+
+export interface DailyTaskConfig {
+  version: number;
+  reset_timezone: string;
+  daily_rotation: {
+    tasks_per_day: number;
+    allow_duplicates_same_day: boolean;
+    reroll_cost_population: number;
+    reroll_limit_per_day: number;
+    selection: {
+      use_weights: boolean;
+      min_tier: number;
+      max_active_per_category: number;
+    };
+  };
+  reward_templates: Record<string, DailyTaskRewardTemplate>;
+  tasks: DailyTaskDefinition[];
+  ui_texts_fi: Record<string, string>;
+  telemetry?: {
+    log_task_rolls?: boolean;
+    log_claims?: boolean;
+    log_buff_start_end?: boolean;
+  };
+}
+
+const config = rawDailyTasks as DailyTaskConfig;
+export const dailyTaskConfig = config;
+
+const tasksById = new Map(config.tasks.map((task) => [task.id, task] as const));
+
+const rngHash = (seed: number, value: string) => {
+  let h = seed ^ 0x9e3779b9;
+  for (let i = 0; i < value.length; i += 1) {
+    h = Math.imul(h ^ value.charCodeAt(i), 0x85ebca6b);
+    h = (h ^ (h >>> 13)) >>> 0;
+  }
+  return h >>> 0;
+};
+
+const createRng = (seed: number) => {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t ^= t + Math.imul(t ^ (t >>> 7), 61 | t);
+    return ((t ^ (t >>> 14)) >>> 0) / 0x100000000;
+  };
+};
+
+const parseTarget = (value: number | string | undefined) => {
+  if (value === undefined) return 0;
+  if (typeof value === 'number') return value;
+  const trimmed = value.trim();
+  const parsed = Number(trimmed);
+  if (!Number.isNaN(parsed)) return parsed;
+  if (/^\d+e\d+$/i.test(trimmed)) {
+    const [base, exp] = trimmed.toLowerCase().split('e');
+    return Number(base) * 10 ** Number(exp);
+  }
+  return 0;
+};
+
+export interface CounterProgressState {
+  type: 'counter';
+  value: number;
+  counts?: Record<string, number>;
+}
+
+export interface ThresholdProgressState {
+  type: 'threshold';
+  value: number;
+  reached: boolean;
+}
+
+export interface DeltaThresholdProgressState {
+  type: 'delta_threshold';
+  value: number;
+  baseline: number;
+  reached: boolean;
+}
+
+export interface StreakProgressState {
+  type: 'streak';
+  lastEventAt: number | null;
+  streakStartAt: number | null;
+  durationMs: number;
+  reached: boolean;
+}
+
+export interface StreakRateProgressState {
+  type: 'streak_rate';
+  lastEventAt: number | null;
+  count: number;
+  reached: boolean;
+}
+
+export interface UptimeProgressState {
+  type: 'uptime';
+  value: number;
+  reached: boolean;
+}
+
+export type DailyTaskProgressState =
+  | CounterProgressState
+  | ThresholdProgressState
+  | DeltaThresholdProgressState
+  | StreakProgressState
+  | StreakRateProgressState
+  | UptimeProgressState;
+
+export interface ActiveBuffState {
+  id: string;
+  sourceTaskId: string;
+  rewardId: string;
+  type: 'temp_gain_mult';
+  value: number;
+  startedAt: number;
+  expiresAt: number;
+}
+
+export interface DailyTaskRuntimeState {
+  baseSeed: number;
+  seed: number;
+  dayKey: string;
+  rolledAt: number;
+  rerollsUsed: number;
+  activeTaskIds: string[];
+  progress: Record<string, DailyTaskProgressState>;
+  completedAt: Record<string, number>;
+  claimedAt: Record<string, number>;
+  activeBuffs: Record<string, ActiveBuffState>;
+  populationEarnedToday: number;
+  uptimeSeconds: number;
+  baselines: {
+    prestigeMultiplier: number;
+  };
+  buffMultiplier: number;
+}
+
+export interface DailyTaskPlayerContext {
+  now: number;
+  tierLevel: number;
+  prestigeMultiplier: number;
+  features: Set<string>;
+  currentPopulation: number;
+  totalPopulation: number;
+}
+
+const ensureBaseSeed = (value: number | undefined) => {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) return value >>> 0;
+  return Math.floor(Math.random() * 0x100000000) >>> 0;
+};
+
+export const createInitialDailyTaskState = (): DailyTaskRuntimeState => ({
+  baseSeed: ensureBaseSeed(undefined),
+  seed: 0,
+  dayKey: '',
+  rolledAt: 0,
+  rerollsUsed: 0,
+  activeTaskIds: [],
+  progress: {},
+  completedAt: {},
+  claimedAt: {},
+  activeBuffs: {},
+  populationEarnedToday: 0,
+  uptimeSeconds: 0,
+  baselines: {
+    prestigeMultiplier: 1,
+  },
+  buffMultiplier: 1,
+});
+
+const getDayInfo = (now: number) => {
+  const zoned = DateTime.fromMillis(now, { zone: config.reset_timezone });
+  const start = zoned.startOf('day');
+  const next = start.plus({ days: 1 });
+  return {
+    dayKey: start.toFormat('yyyy-LL-dd'),
+    startMs: start.toMillis(),
+    nextStartMs: next.toMillis(),
+  };
+};
+
+const computeSeed = (baseSeed: number, dayKey: string, rerollIndex: number) =>
+  rngHash(baseSeed, `${dayKey}:${rerollIndex}`);
+
+const telemetryLog = (
+  type: 'roll' | 'claim' | 'buff-start' | 'buff-end',
+  message: string,
+  detail?: Record<string, unknown>,
+) => {
+  const { telemetry } = config;
+  if (!telemetry) return;
+  if (type === 'roll' && !telemetry.log_task_rolls) return;
+  if (type === 'claim' && !telemetry.log_claims) return;
+  if ((type === 'buff-start' || type === 'buff-end') && !telemetry.log_buff_start_end) return;
+  const data = detail ? ` ${JSON.stringify(detail)}` : '';
+  console.info(`[DailyTasks] ${message}${data}`);
+};
+
+const filterRecords = <T>(
+  source: Record<string, T>,
+  predicate: (taskId: string) => boolean,
+): Record<string, T> => {
+  const next: Record<string, T> = {};
+  for (const [key, value] of Object.entries(source)) {
+    if (predicate(key)) next[key] = value;
+  }
+  return next;
+};
+
+const computeBuffMultiplier = (buffs: Record<string, ActiveBuffState>) => {
+  let mult = 1;
+  for (const buff of Object.values(buffs)) {
+    if (buff.type === 'temp_gain_mult') {
+      mult *= 1 + buff.value;
+    }
+  }
+  return mult;
+};
+
+const withUpdatedProgress = (
+  state: DailyTaskRuntimeState,
+  taskId: string,
+  progress: DailyTaskProgressState,
+): DailyTaskRuntimeState => {
+  const nextProgress = { ...state.progress, [taskId]: progress };
+  return { ...state, progress: nextProgress };
+};
+
+const setCompletionIfNeeded = (
+  state: DailyTaskRuntimeState,
+  taskId: string,
+  condition: DailyTaskCondition,
+  progress: DailyTaskProgressState,
+  now: number,
+): DailyTaskRuntimeState => {
+  const def = tasksById.get(taskId);
+  if (!def) return state;
+  let completed = false;
+  if (condition.type === 'counter') {
+    completed = progress.type === 'counter' && progress.value >= condition.target;
+  } else if (condition.type === 'threshold') {
+    const target = parseTarget(condition.target);
+    completed = progress.type === 'threshold' && progress.value >= target;
+  } else if (condition.type === 'delta_threshold') {
+    const target = parseTarget(condition.target ?? condition.delta ?? 0);
+    completed = progress.type === 'delta_threshold' && progress.value >= target;
+  } else if (condition.type === 'streak') {
+    const target = condition.window_s;
+    completed =
+      progress.type === 'streak' && progress.reached && progress.durationMs >= target * 1000;
+  } else if (condition.type === 'streak_rate') {
+    completed = progress.type === 'streak_rate' && progress.count >= condition.count;
+  } else if (condition.type === 'uptime') {
+    completed = progress.type === 'uptime' && progress.value >= condition.target_s;
+  }
+  if (!completed || state.completedAt[taskId]) return state;
+  const completedAt = { ...state.completedAt, [taskId]: now };
+  return { ...state, completedAt };
+};
+
+export interface RollOptions {
+  force?: boolean;
+  reroll?: boolean;
+}
+
+export const rollDailyTasks = (
+  state: DailyTaskRuntimeState,
+  context: DailyTaskPlayerContext,
+  now: number,
+  options: RollOptions = {},
+): DailyTaskRuntimeState => {
+  const { dayKey } = getDayInfo(now);
+  const isNewDay = dayKey !== state.dayKey;
+  const reroll = !!options.reroll;
+  let next: DailyTaskRuntimeState = state;
+
+  if (isNewDay || options.force) {
+    const baseSeed = ensureBaseSeed(state.baseSeed);
+    const seed = computeSeed(baseSeed, dayKey, 0);
+    next = {
+      ...state,
+      baseSeed,
+      seed,
+      dayKey,
+      rolledAt: now,
+      rerollsUsed: 0,
+      activeTaskIds: [],
+      progress: {},
+      completedAt: {},
+      claimedAt: {},
+      populationEarnedToday: 0,
+      uptimeSeconds: 0,
+      baselines: {
+        prestigeMultiplier: context.prestigeMultiplier,
+      },
+    };
+  }
+
+  if (reroll && !isNewDay) {
+    const nextReroll = state.rerollsUsed + 1;
+    const maxReroll = config.daily_rotation.reroll_limit_per_day;
+    if (nextReroll > maxReroll) return next;
+    const seed = computeSeed(next.baseSeed, next.dayKey, nextReroll);
+    next = {
+      ...next,
+      seed,
+      rerollsUsed: nextReroll,
+      activeTaskIds: [],
+      progress: {},
+      completedAt: {},
+      claimedAt: {},
+    };
+  }
+
+  const { tasks_per_day, allow_duplicates_same_day, selection } = config.daily_rotation;
+  const rng = createRng(next.seed || computeSeed(next.baseSeed, dayKey, next.rerollsUsed));
+
+  const available = config.tasks.filter((task) => {
+    if (selection.min_tier > context.tierLevel) return false;
+    if (task.min_tier > context.tierLevel) return false;
+    if (task.requires_feature && !context.features.has(task.requires_feature)) return false;
+    return true;
+  });
+
+  const chosen: DailyTaskDefinition[] = [];
+  const categoryCounts = new Map<string, number>();
+  let pool = [...available];
+
+  while (chosen.length < tasks_per_day && pool.length > 0) {
+    const totalWeight = pool.reduce((sum, task) => sum + (selection.use_weights ? task.weight : 1), 0);
+    let roll = rng() * totalWeight;
+    let pickedIndex = 0;
+    for (let i = 0; i < pool.length; i += 1) {
+      const weight = selection.use_weights ? pool[i].weight : 1;
+      roll -= weight;
+      if (roll <= 0) {
+        pickedIndex = i;
+        break;
+      }
+    }
+    const [picked] = pool.splice(pickedIndex, 1);
+    if (!picked) break;
+    chosen.push(picked);
+    const count = (categoryCounts.get(picked.category) ?? 0) + 1;
+    categoryCounts.set(picked.category, count);
+    if (!allow_duplicates_same_day) {
+      pool = pool.filter((task) => task.id !== picked.id);
+    }
+    if (selection.max_active_per_category && count >= selection.max_active_per_category) {
+      pool = pool.filter((task) => task.category !== picked.category);
+    }
+  }
+
+  const activeTaskIds = chosen.map((task) => task.id);
+  const nextProgress = filterRecords(next.progress, (taskId) => activeTaskIds.includes(taskId));
+  const nextCompleted = filterRecords(next.completedAt, (taskId) => activeTaskIds.includes(taskId));
+  const nextClaimed = filterRecords(next.claimedAt, (taskId) => activeTaskIds.includes(taskId));
+
+  telemetryLog('roll', 'Rolled daily tasks', {
+    day: dayKey,
+    rerollsUsed: next.rerollsUsed,
+    tasks: activeTaskIds,
+  });
+
+  const buffMultiplier = computeBuffMultiplier(next.activeBuffs);
+
+  let result: DailyTaskRuntimeState = {
+    ...next,
+    seed: computeSeed(next.baseSeed, dayKey, next.rerollsUsed),
+    dayKey,
+    rolledAt: now,
+    activeTaskIds,
+    progress: nextProgress,
+    completedAt: nextCompleted,
+    claimedAt: nextClaimed,
+    buffMultiplier,
+  };
+
+  result = updateMetricProgress(result, 'temperature', context.currentPopulation, now);
+  result = updateMetricProgress(result, 'prestige_multiplier', context.prestigeMultiplier, now);
+  result = updateMetricProgress(result, 'population_earned_today', result.populationEarnedToday, now);
+  result = syncUptimeProgress(result, result.uptimeSeconds, now);
+
+  return result;
+};
+
+const updateCounterProgress = (
+  state: DailyTaskRuntimeState,
+  task: DailyTaskDefinition,
+  now: number,
+  increment: number,
+  key?: string,
+): DailyTaskRuntimeState => {
+  const prev = state.progress[task.id];
+  const counts = prev?.type === 'counter' && prev.counts ? { ...prev.counts } : undefined;
+  let value = prev?.type === 'counter' ? prev.value : 0;
+  if (counts && key) {
+    const current = counts[key] ?? 0;
+    const nextCount = current + increment;
+    counts[key] = nextCount;
+    value = Math.max(value, nextCount);
+  } else if (key) {
+    const nextCounts: Record<string, number> = counts ?? {};
+    const current = nextCounts[key] ?? 0;
+    const nextCount = current + increment;
+    nextCounts[key] = nextCount;
+    value = Math.max(value, nextCount);
+    const progress: CounterProgressState = {
+      type: 'counter',
+      value,
+      counts: nextCounts,
+    };
+    const withProgress = withUpdatedProgress(state, task.id, progress);
+    return setCompletionIfNeeded(withProgress, task.id, task.condition, progress, now);
+  } else {
+    value += increment;
+  }
+
+  const progress: CounterProgressState = {
+    type: 'counter',
+    value,
+    counts,
+  };
+  const withProgress = withUpdatedProgress(state, task.id, progress);
+  return setCompletionIfNeeded(withProgress, task.id, task.condition, progress, now);
+};
+
+export const handleGameEvent = <K extends GameEventType>(
+  state: DailyTaskRuntimeState,
+  context: DailyTaskPlayerContext,
+  type: K,
+  payload: GameEventMap[K],
+): DailyTaskRuntimeState => {
+  if (state.activeTaskIds.length === 0) return state;
+  let next = state;
+  const now = (payload as { timestamp?: number }).timestamp ?? context.now;
+
+  for (const taskId of state.activeTaskIds) {
+    const task = tasksById.get(taskId);
+    if (!task) continue;
+    const condition = task.condition;
+    if (condition.type === 'counter' && condition.event === type) {
+      if (condition.event === 'building_bought_same_type' && type === 'building_bought_same_type') {
+        const key = (payload as GameEventMap['building_bought_same_type']).buildingId;
+        next = updateCounterProgress(next, task, now, 1, key);
+      } else {
+        next = updateCounterProgress(next, task, now, 1);
+      }
+    } else if (condition.type === 'streak' && condition.event === type) {
+      const prev = next.progress[task.id];
+      const streak = prev?.type === 'streak'
+        ? { ...prev }
+        : ({
+            type: 'streak',
+            lastEventAt: null,
+            streakStartAt: null,
+            durationMs: 0,
+            reached: false,
+          } as StreakProgressState);
+      const maxGap = condition.max_gap_s * 1000;
+      if (streak.lastEventAt && now - streak.lastEventAt <= maxGap) {
+        streak.lastEventAt = now;
+        streak.durationMs = streak.streakStartAt ? now - streak.streakStartAt : 0;
+      } else {
+        streak.streakStartAt = now;
+        streak.lastEventAt = now;
+        streak.durationMs = 0;
+      }
+      if (streak.streakStartAt) {
+        streak.durationMs = now - streak.streakStartAt;
+      }
+      if (streak.durationMs >= condition.window_s * 1000) {
+        streak.reached = true;
+      }
+      const withProgress = withUpdatedProgress(next, task.id, streak);
+      next = setCompletionIfNeeded(withProgress, task.id, condition, streak, now);
+    } else if (condition.type === 'streak_rate' && condition.event === type) {
+      const prev = next.progress[task.id];
+      const streakRate = prev?.type === 'streak_rate'
+        ? { ...prev }
+        : ({ type: 'streak_rate', lastEventAt: null, count: 0, reached: false } as StreakRateProgressState);
+      const maxInterval = condition.max_interval_s * 1000;
+      if (streakRate.lastEventAt && now - streakRate.lastEventAt <= maxInterval) {
+        streakRate.count += 1;
+      } else {
+        streakRate.count = 1;
+      }
+      streakRate.lastEventAt = now;
+      if (streakRate.count >= condition.count) streakRate.reached = true;
+      const withProgress = withUpdatedProgress(next, task.id, streakRate);
+      next = setCompletionIfNeeded(withProgress, task.id, condition, streakRate, now);
+    }
+  }
+
+  return next;
+};
+
+export const updateMetricProgress = (
+  state: DailyTaskRuntimeState,
+  metric: 'temperature' | 'prestige_multiplier' | 'population_earned_today',
+  value: number,
+  now: number,
+): DailyTaskRuntimeState => {
+  if (state.activeTaskIds.length === 0) return state;
+  let next = state;
+  for (const taskId of state.activeTaskIds) {
+    const task = tasksById.get(taskId);
+    if (!task) continue;
+    const condition = task.condition;
+    if (condition.type === 'threshold' && condition.metric === metric) {
+      const progress: ThresholdProgressState = {
+        type: 'threshold',
+        value,
+        reached: value >= parseTarget(condition.target),
+      };
+      const withProgress = withUpdatedProgress(next, taskId, progress);
+      next = setCompletionIfNeeded(withProgress, taskId, condition, progress, now);
+    } else if (condition.type === 'delta_threshold' && condition.metric === metric) {
+      const baseline =
+        metric === 'prestige_multiplier'
+          ? state.baselines.prestigeMultiplier
+          : 0;
+      const delta = metric === 'prestige_multiplier' ? value - baseline : value;
+      const progress: DeltaThresholdProgressState = {
+        type: 'delta_threshold',
+        value: Math.max(delta, 0),
+        baseline,
+        reached: Math.max(delta, 0) >= parseTarget(condition.target ?? condition.delta ?? 0),
+      };
+      const withProgress = withUpdatedProgress(next, taskId, progress);
+      next = setCompletionIfNeeded(withProgress, taskId, condition, progress, now);
+    }
+  }
+  return next;
+};
+
+export const addPopulationEarned = (
+  state: DailyTaskRuntimeState,
+  amount: number,
+  now: number,
+): DailyTaskRuntimeState => {
+  if (amount <= 0) return state;
+  const populationEarnedToday = state.populationEarnedToday + amount;
+  const next = { ...state, populationEarnedToday };
+  return updateMetricProgress(next, 'population_earned_today', populationEarnedToday, now);
+};
+
+export const addUptime = (
+  state: DailyTaskRuntimeState,
+  delta: number,
+  now: number,
+): DailyTaskRuntimeState => {
+  if (delta <= 0) return state;
+  const uptimeSeconds = state.uptimeSeconds + delta;
+  let next: DailyTaskRuntimeState = { ...state, uptimeSeconds };
+  for (const taskId of state.activeTaskIds) {
+    const task = tasksById.get(taskId);
+    if (!task) continue;
+    if (task.condition.type !== 'uptime') continue;
+    const prev = state.progress[taskId];
+    const current = prev?.type === 'uptime' ? prev.value : uptimeSeconds - delta;
+    const value = current + delta;
+    const progress: UptimeProgressState = {
+      type: 'uptime',
+      value,
+      reached: value >= task.condition.target_s,
+    };
+    const withProgress = withUpdatedProgress(next, taskId, progress);
+    next = setCompletionIfNeeded(withProgress, taskId, task.condition, progress, now);
+  }
+  return next;
+};
+
+const syncUptimeProgress = (
+  state: DailyTaskRuntimeState,
+  value: number,
+  now: number,
+): DailyTaskRuntimeState => {
+  if (state.activeTaskIds.length === 0) return state;
+  let next = state;
+  for (const taskId of state.activeTaskIds) {
+    const task = tasksById.get(taskId);
+    if (!task || task.condition.type !== 'uptime') continue;
+    const progress: UptimeProgressState = {
+      type: 'uptime',
+      value,
+      reached: value >= task.condition.target_s,
+    };
+    const withProgress = withUpdatedProgress(next, taskId, progress);
+    next = setCompletionIfNeeded(withProgress, taskId, task.condition, progress, now);
+  }
+  return next;
+};
+
+export const expireBuffs = (
+  state: DailyTaskRuntimeState,
+  now: number,
+): DailyTaskRuntimeState => {
+  let changed = false;
+  const activeBuffs: Record<string, ActiveBuffState> = {};
+  for (const [id, buff] of Object.entries(state.activeBuffs)) {
+    if (buff.expiresAt > now) {
+      activeBuffs[id] = buff;
+    } else {
+      telemetryLog('buff-end', 'Buff expired', { id, reward: buff.rewardId });
+      changed = true;
+    }
+  }
+  if (!changed) return state;
+  return { ...state, activeBuffs, buffMultiplier: computeBuffMultiplier(activeBuffs) };
+};
+
+export interface ClaimResult {
+  state: DailyTaskRuntimeState;
+  buff?: ActiveBuffState;
+  success: boolean;
+}
+
+export const claimTaskReward = (
+  state: DailyTaskRuntimeState,
+  taskId: string,
+  now: number,
+): ClaimResult => {
+  if (!state.activeTaskIds.includes(taskId)) return { state, success: false };
+  if (!state.completedAt[taskId] || state.claimedAt[taskId]) return { state, success: false };
+  const def = tasksById.get(taskId);
+  if (!def) return { state, success: false };
+  const rewardTemplate = config.reward_templates[def.reward];
+  if (!rewardTemplate) return { state, success: false };
+
+  const claimedAt = { ...state.claimedAt, [taskId]: now };
+  let activeBuffs = state.activeBuffs;
+  let buff: ActiveBuffState | undefined;
+
+  if (rewardTemplate.type === 'temp_gain_mult') {
+    const expiresAt = now + rewardTemplate.duration_s * 1000;
+    buff = {
+      id: taskId,
+      sourceTaskId: taskId,
+      rewardId: def.reward,
+      type: 'temp_gain_mult',
+      value: rewardTemplate.value,
+      startedAt: now,
+      expiresAt,
+    };
+    activeBuffs = { ...activeBuffs, [buff.id]: buff };
+    telemetryLog('buff-start', 'Buff started', { id: buff.id, reward: buff.rewardId });
+  }
+
+  telemetryLog('claim', 'Reward claimed', { taskId, reward: def.reward });
+
+  return {
+    state: {
+      ...state,
+      claimedAt,
+      activeBuffs,
+      buffMultiplier: computeBuffMultiplier(activeBuffs),
+    },
+    buff,
+    success: true,
+  };
+};
+
+export interface DailyTaskStatus {
+  id: string;
+  definition: DailyTaskDefinition;
+  progress: number;
+  target: number;
+  completed: boolean;
+  claimed: boolean;
+  completedAt?: number;
+  claimedAt?: number;
+}
+
+export const getTaskStatus = (
+  state: DailyTaskRuntimeState,
+  taskId: string,
+): DailyTaskStatus | null => {
+  const def = tasksById.get(taskId);
+  if (!def) return null;
+  const progressState = state.progress[taskId];
+  const completedAt = state.completedAt[taskId];
+  const claimedAt = state.claimedAt[taskId];
+  let progressValue = 0;
+  let target = 0;
+  if (def.condition.type === 'counter') {
+    progressValue = progressState?.type === 'counter' ? progressState.value : 0;
+    target = def.condition.target;
+  } else if (def.condition.type === 'threshold') {
+    progressValue = progressState?.type === 'threshold' ? progressState.value : 0;
+    target = parseTarget(def.condition.target);
+  } else if (def.condition.type === 'delta_threshold') {
+    progressValue = progressState?.type === 'delta_threshold' ? progressState.value : 0;
+    target = parseTarget(def.condition.target ?? def.condition.delta ?? 0);
+  } else if (def.condition.type === 'streak') {
+    progressValue = progressState?.type === 'streak' ? progressState.durationMs / 1000 : 0;
+    target = def.condition.window_s;
+  } else if (def.condition.type === 'streak_rate') {
+    progressValue = progressState?.type === 'streak_rate' ? progressState.count : 0;
+    target = def.condition.count;
+  } else if (def.condition.type === 'uptime') {
+    progressValue = progressState?.type === 'uptime' ? progressState.value : 0;
+    target = def.condition.target_s;
+  }
+  return {
+    id: taskId,
+    definition: def,
+    progress: progressValue,
+    target,
+    completed: !!completedAt,
+    claimed: !!claimedAt,
+    completedAt,
+    claimedAt,
+  };
+};
+
+export const ensureDailyTasks = (
+  state: DailyTaskRuntimeState,
+  context: DailyTaskPlayerContext,
+  now: number,
+): DailyTaskRuntimeState => {
+  const { dayKey } = getDayInfo(now);
+  if (state.dayKey !== dayKey || state.activeTaskIds.length === 0) {
+    return rollDailyTasks(state, context, now, { force: true });
+  }
+  return state;
+};
+

--- a/src/app/events.ts
+++ b/src/app/events.ts
@@ -1,0 +1,89 @@
+export type EventSource = 'click' | 'tick' | 'offline' | 'system';
+
+export interface GameEventMap {
+  loyly_throw: { amount: number; timestamp: number; source: EventSource };
+  click: { amount: number; timestamp: number; source: EventSource };
+  population_gain: {
+    amount: number;
+    timestamp: number;
+    source: EventSource;
+    currentPopulation: number;
+    totalPopulation: number;
+  };
+  building_bought: {
+    buildingId: string;
+    amount: number;
+    price: number;
+    totalOwned: number;
+    timestamp: number;
+  };
+  building_bought_same_type: {
+    buildingId: string;
+    totalOwned: number;
+    timestamp: number;
+  };
+  technology_bought: {
+    techId: string;
+    cost: number;
+    count: number;
+    timestamp: number;
+  };
+  prestige: {
+    timestamp: number;
+    newMultiplier: number;
+    newPoints: number;
+  };
+  tier_unlocked: {
+    timestamp: number;
+    tier: number;
+  };
+  tick: {
+    timestamp: number;
+    delta: number;
+    source: EventSource;
+  };
+}
+
+export type GameEventType = keyof GameEventMap;
+export type GameEventPayload<K extends GameEventType> = GameEventMap[K];
+export type GameEventHandler<K extends GameEventType> = (payload: GameEventPayload<K>) => void;
+
+class EventBus {
+  private listeners = new Map<GameEventType, Set<GameEventHandler<GameEventType>>>();
+
+  on<K extends GameEventType>(type: K, handler: GameEventHandler<K>): () => void {
+    const existing = this.listeners.get(type) ?? new Set<GameEventHandler<GameEventType>>();
+    existing.add(handler as GameEventHandler<GameEventType>);
+    this.listeners.set(type, existing);
+    return () => this.off(type, handler);
+  }
+
+  once<K extends GameEventType>(type: K, handler: GameEventHandler<K>): () => void {
+    const wrap: GameEventHandler<K> = (payload) => {
+      this.off(type, wrap);
+      handler(payload);
+    };
+    return this.on(type, wrap);
+  }
+
+  off<K extends GameEventType>(type: K, handler: GameEventHandler<K>): void {
+    const set = this.listeners.get(type);
+    if (!set) return;
+    set.delete(handler as GameEventHandler<GameEventType>);
+    if (set.size === 0) this.listeners.delete(type);
+  }
+
+  emit<K extends GameEventType>(type: K, payload: GameEventPayload<K>): void {
+    const set = this.listeners.get(type);
+    if (!set) return;
+    for (const handler of Array.from(set)) {
+      (handler as GameEventHandler<K>)(payload);
+    }
+  }
+
+  clear(): void {
+    this.listeners.clear();
+  }
+}
+
+export const gameEvents = new EventBus();

--- a/src/app/gameLoop.ts
+++ b/src/app/gameLoop.ts
@@ -11,7 +11,7 @@ export function startGameLoop() {
   function frame(now: number) {
     const delta = (now - last) / 1000;
     last = now;
-    useGameStore.getState().tick(delta);
+    useGameStore.getState().tick(delta, 'tick');
     sinceSave += delta;
     if (sinceSave >= 5) {
       saveGame();

--- a/src/content/dailyTasks.json
+++ b/src/content/dailyTasks.json
@@ -1,0 +1,274 @@
+{
+  "version": 1,
+  "reset_timezone": "Europe/Helsinki",
+  "daily_rotation": {
+    "tasks_per_day": 3,
+    "allow_duplicates_same_day": false,
+    "reroll_cost_population": 0,
+    "reroll_limit_per_day": 1,
+    "selection": {
+      "use_weights": true,
+      "min_tier": 0,
+      "max_active_per_category": 1
+    }
+  },
+  "reward_templates": {
+    "small_temp_boost": {
+      "type": "temp_gain_mult",
+      "value": 0.15,
+      "duration_s": 600,
+      "cooldown_s": 0
+    },
+    "medium_temp_boost": {
+      "type": "temp_gain_mult",
+      "value": 0.25,
+      "duration_s": 900,
+      "cooldown_s": 0
+    },
+    "large_temp_boost": {
+      "type": "temp_gain_mult",
+      "value": 0.4,
+      "duration_s": 1200,
+      "cooldown_s": 0
+    }
+  },
+  "tasks": [
+    {
+      "id": "loyly_100",
+      "title_fi": "Heitä löylyä 100 kertaa",
+      "desc_fi": "Heitä yhteensä 100 löylyä tänään.",
+      "category": "actions",
+      "condition": { "type": "counter", "event": "loyly_throw", "target": 100 },
+      "reward": "small_temp_boost",
+      "weight": 10,
+      "min_tier": 0,
+      "max_per_day": 1
+    },
+    {
+      "id": "loyly_250",
+      "title_fi": "Heitä löylyä 250 kertaa",
+      "desc_fi": "Heitä yhteensä 250 löylyä tänään.",
+      "category": "actions",
+      "condition": { "type": "counter", "event": "loyly_throw", "target": 250 },
+      "reward": "medium_temp_boost",
+      "weight": 7,
+      "min_tier": 1,
+      "max_per_day": 1
+    },
+    {
+      "id": "loyly_500",
+      "title_fi": "Heitä löylyä 500 kertaa",
+      "desc_fi": "Heitä yhteensä 500 löylyä tänään.",
+      "category": "actions",
+      "condition": { "type": "counter", "event": "loyly_throw", "target": 500 },
+      "reward": "large_temp_boost",
+      "weight": 4,
+      "min_tier": 2,
+      "max_per_day": 1
+    },
+    {
+      "id": "buy_building_1",
+      "title_fi": "Osta 1 uusi rakennus",
+      "desc_fi": "Osta mikä tahansa uusi rakennus.",
+      "category": "economy",
+      "condition": { "type": "counter", "event": "building_bought", "target": 1 },
+      "reward": "small_temp_boost",
+      "weight": 9,
+      "min_tier": 0,
+      "max_per_day": 1
+    },
+    {
+      "id": "buy_building_10",
+      "title_fi": "Osta 10 rakennusta",
+      "desc_fi": "Osta yhteensä 10 rakennusta tänään.",
+      "category": "economy",
+      "condition": { "type": "counter", "event": "building_bought", "target": 10 },
+      "reward": "medium_temp_boost",
+      "weight": 6,
+      "min_tier": 1,
+      "max_per_day": 1
+    },
+    {
+      "id": "buy_tech_1",
+      "title_fi": "Osta yksi uusi teknologia",
+      "desc_fi": "Hanki tänään yksi uusi teknologia.",
+      "category": "tech",
+      "condition": { "type": "counter", "event": "technology_bought", "target": 1 },
+      "reward": "medium_temp_boost",
+      "weight": 8,
+      "min_tier": 0,
+      "max_per_day": 1
+    },
+    {
+      "id": "reach_temp_1e6",
+      "title_fi": "Saavuta 1e6 lämpötila",
+      "desc_fi": "Nosta lämpötila vähintään arvoon 1e6 tänään.",
+      "category": "milestone",
+      "condition": { "type": "threshold", "metric": "temperature", "target": "1e6" },
+      "reward": "small_temp_boost",
+      "weight": 8,
+      "min_tier": 0,
+      "max_per_day": 1
+    },
+    {
+      "id": "reach_temp_1e10",
+      "title_fi": "Saavuta 1e9 lämpötila",
+      "desc_fi": "Nosta lämpötila vähintään arvoon 1e9 tänään.",
+      "category": "milestone",
+      "condition": { "type": "threshold", "metric": "temperature", "target": "1e9" },
+      "reward": "medium_temp_boost",
+      "weight": 6,
+      "min_tier": 1,
+      "max_per_day": 1
+    },
+    {
+      "id": "reach_temp_1e16",
+      "title_fi": "Saavuta 1e12 lämpötila",
+      "desc_fi": "Nosta lämpötila vähintään arvoon 1e12 tänään.",
+      "category": "milestone",
+      "condition": { "type": "threshold", "metric": "temperature", "target": "1e12" },
+      "reward": "large_temp_boost",
+      "weight": 4,
+      "min_tier": 2,
+      "max_per_day": 1
+    },
+    {
+      "id": "combo_streak_60s",
+      "title_fi": "Löylyputki 60 s",
+      "desc_fi": "Pidä löylyputki yllä 60 sekuntia (heittoja ilman yli 2 s taukoa).",
+      "category": "skill",
+      "condition": {
+        "type": "streak",
+        "event": "loyly_throw",
+        "window_s": 60,
+        "max_gap_s": 2
+      },
+      "reward": "medium_temp_boost",
+      "weight": 5,
+      "min_tier": 1,
+      "max_per_day": 1
+    },
+    {
+      "id": "prestige_once",
+      "title_fi": "Polta sauna kerran",
+      "desc_fi": "Käytä Polta sauna tänään vähintään kerran.",
+      "category": "prestige",
+      "condition": { "type": "counter", "event": "prestige", "target": 1 },
+      "reward": "large_temp_boost",
+      "weight": 3,
+      "min_tier": 2,
+      "requires_feature": "prestige",
+      "max_per_day": 1
+    },
+    {
+      "id": "increase_prestige_mult",
+      "title_fi": "Kasvata polta sauna -kerrointa",
+      "desc_fi": "Nosta pysyvää kerrointa vähintään +1 tänään.",
+      "category": "prestige",
+      "condition": {
+        "type": "delta_threshold",
+        "metric": "prestige_multiplier",
+        "delta": 1
+      },
+      "reward": "large_temp_boost",
+      "weight": 2,
+      "min_tier": 3,
+      "requires_feature": "prestige",
+      "max_per_day": 1
+    },
+    {
+      "id": "upgrade_same_building_3",
+      "title_fi": "Päivitä samaa rakennusta 3 kertaa",
+      "desc_fi": "Tee kolme ostoa samaan rakennukseen tänään.",
+      "category": "economy",
+      "condition": {
+        "type": "counter",
+        "event": "building_bought_same_type",
+        "target": 3
+      },
+      "reward": "small_temp_boost",
+      "weight": 6,
+      "min_tier": 0,
+      "max_per_day": 1
+    },
+    {
+      "id": "unlock_next_tier",
+      "title_fi": "Avaa seuraava taso",
+      "desc_fi": "Etene seuraavaan tieriin tänään.",
+      "category": "progression",
+      "condition": { "type": "counter", "event": "tier_unlocked", "target": 1 },
+      "reward": "medium_temp_boost",
+      "weight": 4,
+      "min_tier": 1,
+      "max_per_day": 1
+    },
+    {
+      "id": "earn_population_today",
+      "title_fi": "Ansaitse 1e7 lämpötilaa tänään",
+      "desc_fi": "Kasvata päivän netto-lämpöä vähintään 1e7.",
+      "category": "economy",
+      "condition": {
+        "type": "delta_threshold",
+        "metric": "population_earned_today",
+        "target": "1e7"
+      },
+      "reward": "medium_temp_boost",
+      "weight": 6,
+      "min_tier": 1,
+      "max_per_day": 1
+    },
+    {
+      "id": "clicks_1000",
+      "title_fi": "Tee 1000 klikkausta",
+      "desc_fi": "Klikkaa yhteensä 1000 kertaa tänään.",
+      "category": "actions",
+      "condition": { "type": "counter", "event": "click", "target": 1000 },
+      "reward": "large_temp_boost",
+      "weight": 3,
+      "min_tier": 2,
+      "max_per_day": 1
+    },
+    {
+      "id": "session_10min",
+      "title_fi": "Saunavuoro 10 minuuttia",
+      "desc_fi": "Pidä peli auki yhtäjaksoisesti 10 minuuttia.",
+      "category": "time",
+      "condition": { "type": "uptime", "target_s": 600 },
+      "reward": "small_temp_boost",
+      "weight": 8,
+      "min_tier": 0,
+      "max_per_day": 1
+    },
+    {
+      "id": "fast_casts_5",
+      "title_fi": "Nopeat heitot ×5",
+      "desc_fi": "Tee 5 peräkkäistä löylynheittoa alle 1 s välein.",
+      "category": "skill",
+      "condition": {
+        "type": "streak_rate",
+        "event": "loyly_throw",
+        "count": 5,
+        "max_interval_s": 1
+      },
+      "reward": "small_temp_boost",
+      "weight": 6,
+      "min_tier": 0,
+      "max_per_day": 1
+    }
+  ],
+  "ui_texts_fi": {
+    "daily_tasks_title": "Päivän tehtävät",
+    "completed": "Valmis",
+    "claim_reward": "Lunasta tarjous",
+    "reward_active": "Päivitys aktiivinen",
+    "reward_expired": "Päivitys päättynyt",
+    "resets_in": "Uusiutuu",
+    "progress": "Edistyminen",
+    "of": "/"
+  },
+  "telemetry": {
+    "log_task_rolls": true,
+    "log_claims": true,
+    "log_buff_start_end": true
+  }
+}

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -2,12 +2,14 @@ import buildingsData from './buildings.json' assert { type: 'json' };
 import techData from './tech.json' assert { type: 'json' };
 import tiersData from './tiers.json' assert { type: 'json' };
 import prestigeData from './prestige.json' assert { type: 'json' };
+import dailyTasksData from './dailyTasks.json' assert { type: 'json' };
 import type { BuildingDef, TechDef, TierDef, PrestigeDef } from './types';
 
 export const buildings = buildingsData as BuildingDef[];
 export const tech = techData as TechDef[];
 export const tiers = tiersData as TierDef[];
 export const prestige = prestigeData as PrestigeDef;
+export const dailyTasks = dailyTasksData;
 
 export const getBuilding = (id: string) => buildings.find((b) => b.id === id);
 export const getTech = (id: string) => tech.find((t) => t.id === id);


### PR DESCRIPTION
## Summary
- add Europe/Helsinki daily task configuration JSON and export it from the content index
- implement a daily task engine that rolls weighted tasks, tracks progress and claims, and manages reward buffs with deterministic seeding
- introduce an event bus plus store/game loop wiring so daily progress, uptime, rerolls, and buff expiry persist across sessions
- add luxon dependency for timezone-aware day boundaries

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca682820608328840e278aeaf14328