### PR TITLE
Disable Polta Maailma button when no award is available

### DIFF
--- a/src/ui/PoltaMaailmaButton.test.tsx
+++ b/src/ui/PoltaMaailmaButton.test.tsx
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { PoltaMaailmaButton } from './PoltaMaailmaButton';
+import { useGameStore } from '../app/store';
+
+describe('PoltaMaailmaButton', () => {
+  beforeEach(() => {
+    useGameStore.persist.clearStorage();
+    useGameStore.setState((state) => ({
+      ...state,
+      tierLevel: 1,
+      prestigeMult: 1,
+      maailma: {
+        ...state.maailma,
+        tuhka: '0',
+        totalTuhkaEarned: '0',
+      },
+    }));
+  });
+
+  it('disables the reset button when no award is available', () => {
+    render(<PoltaMaailmaButton />);
+
+    const button = screen.getByRole('button', { name: /polta maailma/i });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute(
+      'title',
+      'Et ansaitse vielä Tuhkaa polttamalla maailman.',
+    );
+  });
+});
+

--- a/src/ui/PoltaMaailmaButton.tsx
+++ b/src/ui/PoltaMaailmaButton.tsx
@@ -40,6 +40,11 @@ export function PoltaMaailmaButton() {
     return getTuhkaAwardPreview();
   }, [tierLevel, prestigeMult, tuhka, totalTuhkaEarned]);
 
+  const canPoltaMaailma = preview.award > 0n;
+  const disabledTooltip = canPoltaMaailma
+    ? undefined
+    : 'Et ansaitse vielä Tuhkaa polttamalla maailman.';
+
   const showToast = (message: string) => {
     setToastMessage(message);
     if (toastTimerRef.current !== undefined) {
@@ -108,6 +113,8 @@ export function PoltaMaailmaButton() {
           type="button"
           className="btn btn--primary"
           onClick={() => setModalOpen(true)}
+          disabled={!canPoltaMaailma}
+          title={disabledTooltip}
           style={{
             background: '#b91c1c',
             color: '#fff',


### PR DESCRIPTION
## Summary
- disable the Polta Maailma button when no Tuhka award is available and show a tooltip explaining why
- add a unit test to ensure the button stays disabled when the previewed award is zero

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cab60d53b48328a08e85dfb11fc689