### PR TITLE
Add daily tasks panel with notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [Unreleased]
+### Added
+- Daily task panel alongside the HUD including progress tracking, reward claiming, and localized messaging.
+- Toast notifications for task completion, reward claims, and buff lifecycle events.
+- Responsive styling for the HUD and daily task layout including active buff timers.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { useGameStore } from './app/store';
 import './App.css';
 import { playTierMusic } from './audio/music';
 import { useSettingsStore } from './app/settingsStore';
+import { DailyTasksPanel } from './app/dailyTasksUI';
 
 function App() {
   const tierLevel = useGameStore((s) => s.tierLevel);
@@ -52,7 +53,12 @@ function App() {
         </div>
       )}
       <Settings />
-      <HUD />
+      <div className="app__top">
+        <div className="app__top-section">
+          <HUD />
+        </div>
+        <DailyTasksPanel />
+      </div>
       <PrestigeCard />
       <BuildingsGrid />
       <TechGrid />

--- a/src/app/dailyTasksUI.tsx
+++ b/src/app/dailyTasksUI.tsx
@@ -1,0 +1,284 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { DateTime } from 'luxon';
+import {
+  dailyTaskConfig,
+  getTaskStatus,
+  type ActiveBuffState,
+  type DailyTaskDefinition,
+  type DailyTaskRuntimeState,
+  type DailyTaskStatus,
+} from './dailyTasks';
+import { useGameStore } from './store';
+import { formatNumber } from '../utils/format';
+
+type ToastTone = 'info' | 'success' | 'warning';
+
+interface ToastMessage {
+  id: number;
+  text: string;
+  tone: ToastTone;
+  expiresAt: number;
+}
+
+type ToastProducer = (text: string, tone?: ToastTone) => void;
+
+const uiText = dailyTaskConfig.ui_texts_fi;
+
+const taskDefinitionById = new Map<string, DailyTaskDefinition>(
+  dailyTaskConfig.tasks.map((task) => [task.id, task]),
+);
+
+const formatDuration = (milliseconds: number) => {
+  const totalSeconds = Math.max(0, Math.floor(milliseconds / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const timeParts = [
+    hours > 0 ? String(hours) : null,
+    hours > 0 ? String(minutes).padStart(2, '0') : String(minutes),
+    String(seconds).padStart(2, '0'),
+  ].filter((part): part is string => part !== null);
+  return timeParts.join(':');
+};
+
+const formatPercent = (value: number) =>
+  new Intl.NumberFormat(undefined, {
+    style: 'percent',
+    minimumFractionDigits: value < 0.1 ? 1 : 0,
+    maximumFractionDigits: value < 0.1 ? 1 : 0,
+  }).format(value);
+
+const useTaskStatuses = (daily: DailyTaskRuntimeState): DailyTaskStatus[] =>
+  useMemo(
+    () =>
+      daily.activeTaskIds
+        .map((taskId) => getTaskStatus(daily, taskId))
+        .filter((status): status is DailyTaskStatus => status !== null),
+    [daily],
+  );
+
+const useToasts = (): [ToastMessage[], ToastProducer] => {
+  const [toasts, setToasts] = useState<ToastMessage[]>([]);
+  const addToast = useCallback<ToastProducer>((text, tone = 'info') => {
+    setToasts((prev) => {
+      const now = Date.now();
+      const toast: ToastMessage = {
+        id: now + Math.random(),
+        text,
+        tone,
+        expiresAt: now + 5000,
+      };
+      return [...prev, toast];
+    });
+  }, []);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      setToasts((prev) => prev.filter((toast) => toast.expiresAt > Date.now()));
+    }, 1000);
+    return () => window.clearInterval(timer);
+  }, []);
+
+  return [toasts, addToast];
+};
+
+const computeResetCountdown = (now: number) => {
+  const zoned = DateTime.fromMillis(now, { zone: dailyTaskConfig.reset_timezone });
+  const start = zoned.startOf('day');
+  const next = start.plus({ days: 1 });
+  return Math.max(0, next.toMillis() - now);
+};
+
+const getBuffTaskTitle = (buff: ActiveBuffState) =>
+  taskDefinitionById.get(buff.sourceTaskId)?.title_fi ?? buff.sourceTaskId;
+
+interface DailyTaskCardProps {
+  status: DailyTaskStatus;
+  onClaim: (taskId: string) => void;
+}
+
+const DailyTaskCard = ({ status, onClaim }: DailyTaskCardProps) => {
+  const { definition, completed, claimed, target, progress } = status;
+  const effectiveTarget = target > 0 ? target : Math.max(progress, 1);
+  const cappedProgress = Math.min(progress, effectiveTarget);
+  const percent = effectiveTarget > 0 ? Math.min(100, (cappedProgress / effectiveTarget) * 100) : 0;
+  const canClaim = completed && !claimed;
+
+  return (
+    <article
+      className={`daily-task-card${completed ? ' daily-task-card--completed' : ''}${
+        claimed ? ' daily-task-card--claimed' : ''
+      }`}
+    >
+      <header className="daily-task-card__header">
+        <h3 className="daily-task-card__title">{definition.title_fi}</h3>
+        <p className="daily-task-card__description">{definition.desc_fi}</p>
+      </header>
+      <div className="daily-task-card__progress">
+        <label className="daily-task-card__progress-label">
+          {uiText.progress}: {formatNumber(cappedProgress)} {uiText.of} {formatNumber(effectiveTarget)}
+        </label>
+        <progress className="daily-task-card__progress-bar" max={effectiveTarget} value={cappedProgress}>
+          {percent.toFixed(0)}%
+        </progress>
+      </div>
+      <footer className="daily-task-card__footer">
+        {claimed ? (
+          <span className="daily-task-card__badge daily-task-card__badge--claimed">
+            {uiText.claim_reward}
+          </span>
+        ) : canClaim ? (
+          <button
+            type="button"
+            className="btn btn--primary daily-task-card__claim"
+            onClick={() => onClaim(status.id)}
+          >
+            {uiText.claim_reward}
+          </button>
+        ) : completed ? (
+          <span className="daily-task-card__badge daily-task-card__badge--completed">
+            {uiText.completed}
+          </span>
+        ) : null}
+      </footer>
+    </article>
+  );
+};
+
+interface BuffListProps {
+  buffs: ActiveBuffState[];
+  now: number;
+}
+
+const ActiveBuffList = ({ buffs, now }: BuffListProps) => {
+  if (buffs.length === 0) {
+    return null;
+  }
+  return (
+    <div className="daily-task-buffs">
+      <h4 className="daily-task-buffs__title">{uiText.reward_active}</h4>
+      <ul className="daily-task-buffs__list">
+        {buffs.map((buff) => {
+          const remaining = Math.max(0, buff.expiresAt - now);
+          return (
+            <li key={buff.id} className="daily-task-buffs__item">
+              <span className="daily-task-buffs__name">{getBuffTaskTitle(buff)}</span>
+              <span className="daily-task-buffs__value">{formatPercent(buff.value)}</span>
+              <span className="daily-task-buffs__timer">{formatDuration(remaining)}</span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+export function DailyTasksPanel() {
+  const daily = useGameStore((state) => state.daily);
+  const claimReward = useGameStore((state) => state.claimDailyTaskReward);
+  const [now, setNow] = useState(() => Date.now());
+  const [toasts, pushToast] = useToasts();
+  const handleClaim = useCallback(
+    (taskId: string) => {
+      try {
+        claimReward(taskId);
+      } catch (error) {
+        console.error('Failed to claim daily task reward', error);
+        pushToast(`${uiText.claim_reward}: ${taskId}`, 'warning');
+      }
+    },
+    [claimReward, pushToast],
+  );
+  const tasks = useTaskStatuses(daily);
+  const resetCountdown = useMemo(() => computeResetCountdown(now), [now]);
+  const activeBuffs = useMemo(
+    () =>
+      Object.values(daily.activeBuffs)
+        .slice()
+        .sort((a, b) => a.expiresAt - b.expiresAt),
+    [daily.activeBuffs],
+  );
+
+  const previousCompleted = useRef<Set<string>>(new Set());
+  const previousClaimed = useRef<Set<string>>(new Set());
+  const previousBuffIds = useRef<Set<string>>(new Set());
+  const initialized = useRef(false);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(timer);
+  }, []);
+
+  useEffect(() => {
+    const completedNow = new Set(tasks.filter((task) => task.completed).map((task) => task.id));
+    const claimedNow = new Set(tasks.filter((task) => task.claimed).map((task) => task.id));
+    const activeBuffIds = new Set(Object.keys(daily.activeBuffs));
+
+    if (!initialized.current) {
+      previousCompleted.current = completedNow;
+      previousClaimed.current = claimedNow;
+      previousBuffIds.current = activeBuffIds;
+      initialized.current = true;
+      return;
+    }
+
+    for (const task of tasks) {
+      if (task.completed && !previousCompleted.current.has(task.id)) {
+        pushToast(`${task.definition.title_fi} – ${uiText.completed}`, 'info');
+      }
+      if (task.claimed && !previousClaimed.current.has(task.id)) {
+        pushToast(`${task.definition.title_fi} – ${uiText.claim_reward}`, 'success');
+      }
+    }
+
+    for (const buffId of activeBuffIds) {
+      if (!previousBuffIds.current.has(buffId)) {
+        const title = taskDefinitionById.get(buffId)?.title_fi ?? buffId;
+        pushToast(`${title} – ${uiText.reward_active}`, 'success');
+      }
+    }
+
+    for (const buffId of previousBuffIds.current) {
+      if (!activeBuffIds.has(buffId)) {
+        const title = taskDefinitionById.get(buffId)?.title_fi ?? buffId;
+        pushToast(`${title} – ${uiText.reward_expired}`, 'warning');
+      }
+    }
+
+    previousCompleted.current = completedNow;
+    previousClaimed.current = claimedNow;
+    previousBuffIds.current = activeBuffIds;
+  }, [tasks, daily.activeBuffs, pushToast]);
+
+  if (tasks.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="daily-tasks-panel" aria-label={uiText.daily_tasks_title}>
+      <header className="daily-tasks-panel__header">
+        <h2 className="daily-tasks-panel__title">{uiText.daily_tasks_title}</h2>
+        <div className="daily-tasks-panel__timer">
+          {uiText.resets_in}: {formatDuration(resetCountdown)}
+        </div>
+      </header>
+      <ActiveBuffList buffs={activeBuffs} now={now} />
+      <div className="daily-tasks-panel__list">
+        {tasks.map((task) => (
+          <DailyTaskCard key={task.id} status={task} onClaim={handleClaim} />
+        ))}
+      </div>
+      {toasts.length > 0 && (
+        <div className="daily-tasks-toasts" role="status" aria-live="polite">
+          {toasts.map((toast) => (
+            <div key={toast.id} className={`daily-tasks-toast daily-tasks-toast--${toast.tone}`}>
+              {toast.text}
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default DailyTasksPanel;

--- a/src/index.css
+++ b/src/index.css
@@ -204,3 +204,233 @@ h1 {
     height: 2px;
   }
 }
+
+.app__top {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: stretch;
+  gap: 1.5rem;
+  width: min(100%, 960px);
+  margin: 1rem auto 0;
+}
+
+.app__top-section {
+  flex: 1 1 280px;
+  min-width: 260px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.daily-tasks-panel {
+  flex: 1 1 320px;
+  min-width: 280px;
+  max-width: 420px;
+  background: color-mix(in srgb, var(--surface-elevated) 90%, transparent);
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+}
+
+.daily-tasks-panel__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.daily-tasks-panel__title {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.daily-tasks-panel__timer {
+  font-size: 0.9rem;
+  opacity: 0.75;
+}
+
+.daily-tasks-panel__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.daily-task-card {
+  background: var(--surface-elevated);
+  border-radius: 0.75rem;
+  padding: 0.9rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.daily-task-card--completed {
+  border-color: color-mix(in srgb, var(--brand-primary) 60%, transparent);
+  box-shadow: 0 4px 12px rgba(100, 108, 255, 0.25);
+}
+
+.daily-task-card--claimed {
+  opacity: 0.85;
+}
+
+.daily-task-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.daily-task-card__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  text-align: left;
+}
+
+.daily-task-card__description {
+  margin: 0;
+  font-size: 0.9rem;
+  opacity: 0.8;
+  text-align: left;
+}
+
+.daily-task-card__progress-label {
+  display: block;
+  font-size: 0.8rem;
+  opacity: 0.85;
+  text-align: left;
+  margin-bottom: 0.35rem;
+}
+
+.daily-task-card__progress-bar {
+  width: 100%;
+  height: 0.6rem;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.daily-task-card__footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.daily-task-card__claim {
+  width: fit-content;
+}
+
+.daily-task-card__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  background: color-mix(in srgb, var(--brand-primary) 25%, transparent);
+}
+
+.daily-task-card__badge--claimed {
+  background: color-mix(in srgb, #4caf50 30%, transparent);
+}
+
+.daily-task-card__badge--completed {
+  background: color-mix(in srgb, var(--brand-primary) 40%, transparent);
+}
+
+.daily-task-buffs {
+  border-radius: 0.65rem;
+  padding: 0.75rem 1rem;
+  background: color-mix(in srgb, var(--surface) 80%, transparent);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.daily-task-buffs__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  text-align: left;
+}
+
+.daily-task-buffs__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.daily-task-buffs__item {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+}
+
+.daily-task-buffs__name {
+  flex: 1;
+  text-align: left;
+}
+
+.daily-task-buffs__value {
+  font-variant-numeric: tabular-nums;
+}
+
+.daily-task-buffs__timer {
+  font-variant-numeric: tabular-nums;
+  opacity: 0.8;
+}
+
+.daily-tasks-toasts {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 1100;
+  pointer-events: none;
+}
+
+.daily-tasks-toast {
+  background: var(--surface-elevated);
+  color: var(--color-text);
+  padding: 0.75rem 1rem;
+  border-radius: 0.6rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  border-left: 4px solid var(--brand-primary);
+  font-size: 0.9rem;
+  pointer-events: auto;
+}
+
+.daily-tasks-toast--success {
+  border-left-color: #4caf50;
+}
+
+.daily-tasks-toast--warning {
+  border-left-color: #f5a623;
+}
+
+@media (max-width: 720px) {
+  .app__top {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .daily-tasks-panel {
+    max-width: none;
+    width: 100%;
+  }
+
+  .daily-tasks-toasts {
+    right: 0.75rem;
+    left: 0.75rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a daily task panel that surfaces localized task progress, claim actions, and toast notifications
- show active buff timers and reset countdowns while integrating error handling for claims
- refresh the HUD layout, responsive styling, and changelog entry to accommodate the new panel

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cabbbe512083288c0c9eacacec76cc