### PR TITLE
Set Vite base path to root

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: '/Suomidle/',
+  base: '/',
   // @ts-expect-error - Vitest config
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- update the Vite configuration to serve assets from the root path to support default deployments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cac4e4904083289a94684ba4fc3db7