### PR TITLE
Add CNAME for custom domain deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [Unreleased]
+### Added
+- Configure deployments to publish the `aaroonparas.com` CNAME record.

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+aaroonparas.com


### PR DESCRIPTION
## Summary
- add a CNAME file under public to publish the aaroonparas.com record during deploys
- document the new deployment configuration in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cac4f1a78483288ef7fbc8497fd986