### PR TITLE
feat: persist temp gain buffs in store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,5 @@
 - Daily task panel alongside the HUD including progress tracking, reward claiming, and localized messaging.
 - Toast notifications for task completion, reward claims, and buff lifecycle events.
 - Responsive styling for the HUD and daily task layout including active buff timers.
+### Changed
+- Population-per-second and click rewards now apply stacked temporary gain buffs that persist across sessions, recalculate on state changes, and automatically expire.


### PR DESCRIPTION
## Summary
- persist active temporary gain multiplier buffs in the root store and clean up expired entries
- update recompute, tick, and click flows to apply stacked buff multipliers and sync with daily task helpers
- extend the daily task manager with buff snapshot utilities and add regression coverage for buff-driven gains

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cac150c6fc8328bce9835d578bc682