### PR TITLE
fix: allow legacy saves to overwrite new-domain progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,5 @@
 ### Fixed
 - Ensure the legacy migration overwrites any new-domain saves once so existing
   progress from GitHub Pages wins.
+- Block the initial render until the legacy data migration completes so
+  existing progress appears immediately.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,8 @@
 ## [Unreleased]
 ### Added
 - Configure deployments to publish the `aaroonparas.com` CNAME record.
+- Automatically migrate saved games and settings from the legacy GitHub Pages
+  origin to the new `aaroonparas.com` domain.
+### Fixed
+- Ensure the legacy migration overwrites any new-domain saves once so existing
+  progress from GitHub Pages wins.

--- a/public/migration-proxy.html
+++ b/public/migration-proxy.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Suomidle Save Migration Proxy</title>
+    <meta name="robots" content="noindex" />
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: #0b0d16;
+        color: #f0f3ff;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      }
+      body {
+        display: flex;
+        min-height: 100vh;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.875rem;
+      }
+    </style>
+  </head>
+  <body>
+    <p>Preparing Suomidle save data…</p>
+    <script>
+      (function () {
+        const REQUEST_TYPE = 'suomidle-legacy-migration-request-v1';
+        const RESPONSE_TYPE = 'suomidle-legacy-migration-response-v1';
+        const STORAGE_KEYS = ['suomidle', 'settings'];
+        const ALLOWED_ORIGINS = new Set([
+          'https://aaroonparas.com',
+          'https://www.aaroonparas.com',
+          'http://localhost:5173',
+          'http://127.0.0.1:5173',
+          'http://localhost:4173',
+          'http://127.0.0.1:4173',
+          'http://localhost',
+          'http://127.0.0.1',
+        ]);
+
+        const toErrorMessage = (error) => {
+          if (!error) return undefined;
+          if (typeof error === 'string') return error;
+          if (error instanceof Error && typeof error.message === 'string') return error.message;
+          try {
+            return JSON.stringify(error);
+          } catch (serializationError) {
+            return String(serializationError && serializationError.message ? serializationError.message : error);
+          }
+        };
+
+        const readPayload = () => {
+          const payload = {};
+          for (const key of STORAGE_KEYS) {
+            try {
+              const value = window.localStorage.getItem(key);
+              if (typeof value === 'string') {
+                payload[key] = value;
+              }
+            } catch (error) {
+              return { error: toErrorMessage(error) };
+            }
+          }
+          return { payload };
+        };
+
+        window.addEventListener('message', (event) => {
+          if (!event || !event.data || event.data.type !== REQUEST_TYPE) return;
+          if (!ALLOWED_ORIGINS.has(event.origin)) return;
+          if (!event.source) return;
+
+          const { requestId } = event.data;
+          const result = readPayload();
+          const payload = result.payload && typeof result.payload === 'object' ? result.payload : undefined;
+          const payloadSize = payload ? Object.keys(payload).length : 0;
+          const status = result.error ? 'error' : payloadSize > 0 ? 'ok' : 'empty';
+
+          event.source.postMessage(
+            {
+              type: RESPONSE_TYPE,
+              requestId,
+              status,
+              payload: result.error ? undefined : payload,
+              error: result.error,
+            },
+            event.origin,
+          );
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -80,7 +80,7 @@ interface Actions {
 
 type State = BaseState & Actions;
 
-const STORAGE_KEY = 'suomidle';
+export const STORAGE_KEY = 'suomidle';
 const decimalZero = new Decimal(0);
 
 type RawMaailmaShopItem = {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,10 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import App from './App.tsx'
 import { ensureLegacyStorageMigrated } from './utils/legacyStorageMigration.ts'
 
 await ensureLegacyStorageMigrated()
+const { default: App } = await import('./App.tsx')
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,9 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { ensureLegacyStorageMigrated } from './utils/legacyStorageMigration.ts'
+
+await ensureLegacyStorageMigrated()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/tests/legacyStorageMigration.test.ts
+++ b/src/tests/legacyStorageMigration.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { ensureLegacyStorageMigrated, MIGRATION_STATE_KEY } from '../utils/legacyStorageMigration'
+
+const RESPONSE_TYPE = 'suomidle-legacy-migration-response-v1'
+const IFRAME_SELECTOR = 'iframe[data-suomidle-migration-proxy]'
+const nextTick = () => Promise.resolve()
+
+describe('legacy storage migration', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.body.innerHTML = '<div id="root"></div>'
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  test('imports save data from the legacy origin when available', async () => {
+    const migration = ensureLegacyStorageMigrated({
+      force: true,
+      requestIdOverride: 'request-123',
+      requestTimeoutMs: 250,
+    })
+
+    await nextTick()
+
+    expect(document.querySelector(IFRAME_SELECTOR)).not.toBeNull()
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: 'https://aaroaskala.github.io',
+        data: {
+          type: RESPONSE_TYPE,
+          requestId: 'request-123',
+          status: 'ok',
+          payload: {
+            suomidle: '{"legacy":true}',
+            settings: '{"volume":0.5}',
+          },
+        },
+      }),
+    )
+
+    await migration
+
+    expect(localStorage.getItem('suomidle')).toBe('{"legacy":true}')
+    expect(localStorage.getItem('settings')).toBe('{"volume":0.5}')
+    expect(localStorage.getItem(MIGRATION_STATE_KEY)).toBe('complete')
+    expect(document.querySelector(IFRAME_SELECTOR)).toBeNull()
+  })
+
+  test('overwrites an existing save with the legacy data exactly once', async () => {
+    localStorage.setItem('suomidle', '{"fresh":true}')
+    localStorage.setItem('settings', '{"volume":1}')
+
+    const migration = ensureLegacyStorageMigrated({
+      force: true,
+      requestIdOverride: 'force-test',
+      requestTimeoutMs: 250,
+    })
+
+    await nextTick()
+
+    expect(document.querySelector(IFRAME_SELECTOR)).not.toBeNull()
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: 'https://aaroaskala.github.io',
+        data: {
+          type: RESPONSE_TYPE,
+          requestId: 'force-test',
+          status: 'ok',
+          payload: {
+            suomidle: '{"legacy":true}',
+            settings: '{"volume":0.4}',
+          },
+        },
+      }),
+    )
+
+    await migration
+
+    expect(localStorage.getItem('suomidle')).toBe('{"legacy":true}')
+    expect(localStorage.getItem('settings')).toBe('{"volume":0.4}')
+    expect(localStorage.getItem(MIGRATION_STATE_KEY)).toBe('complete')
+    expect(document.querySelector(IFRAME_SELECTOR)).toBeNull()
+
+    await ensureLegacyStorageMigrated({ hostnameOverride: 'aaroonparas.com' })
+
+    expect(document.querySelector(IFRAME_SELECTOR)).toBeNull()
+    expect(localStorage.getItem('suomidle')).toBe('{"legacy":true}')
+    expect(localStorage.getItem(MIGRATION_STATE_KEY)).toBe('complete')
+  })
+
+  test('resolves after timing out when the legacy origin is unreachable', async () => {
+    vi.useFakeTimers()
+
+    const migration = ensureLegacyStorageMigrated({
+      force: true,
+      requestIdOverride: 'timeout',
+      requestTimeoutMs: 10,
+    })
+
+    await nextTick()
+
+    await vi.advanceTimersByTimeAsync(20)
+
+    await migration
+
+    expect(localStorage.getItem('suomidle')).toBeNull()
+    expect(localStorage.getItem(MIGRATION_STATE_KEY)).toBeNull()
+    expect(document.querySelector(IFRAME_SELECTOR)).toBeNull()
+  })
+})

--- a/src/utils/legacyStorageMigration.ts
+++ b/src/utils/legacyStorageMigration.ts
@@ -1,0 +1,210 @@
+const LEGACY_ORIGIN = 'https://aaroaskala.github.io'
+const LEGACY_MIGRATION_PATH = '/Suomidle/migration-proxy.html'
+const REQUEST_MESSAGE_TYPE = 'suomidle-legacy-migration-request-v1'
+const RESPONSE_MESSAGE_TYPE = 'suomidle-legacy-migration-response-v1'
+export const MIGRATION_STATE_KEY = 'suomidle:migration:v1'
+const MIGRATION_STATE_VALUE = 'complete'
+const GAME_STORAGE_KEY = 'suomidle'
+const SETTINGS_STORAGE_KEY = 'settings'
+const MIGRATION_SUPPORTED_HOSTS = new Set([
+  'aaroonparas.com',
+  'www.aaroonparas.com',
+  'localhost',
+  '127.0.0.1',
+])
+const DEFAULT_TIMEOUT_MS = 5000
+const MIGRATION_IFRAME_ATTRIBUTE = 'data-suomidle-migration-proxy'
+
+interface LegacyResponseMessage {
+  type?: string
+  requestId?: string
+  status?: 'ok' | 'empty' | 'error'
+  payload?: Record<string, unknown>
+  error?: unknown
+}
+
+export interface LegacyMigrationOptions {
+  /**
+   * Forces a migration attempt regardless of hostname or previous state.
+   * Primarily intended for testing.
+   */
+  force?: boolean
+  /**
+   * Overrides the timeout used for the migration request (defaults to 5 seconds).
+   */
+  requestTimeoutMs?: number
+  /**
+   * Overrides the generated request ID. Primarily intended for tests.
+   */
+  requestIdOverride?: string
+  /**
+   * Overrides the detected hostname. Primarily intended for tests.
+   */
+  hostnameOverride?: string
+}
+
+const hasWindowSupport = () => typeof window !== 'undefined'
+
+const hasDocumentSupport = () => typeof document !== 'undefined'
+
+const hasLocalStorageSupport = () => {
+  if (!hasWindowSupport()) return false
+  try {
+    void window.localStorage
+    return true
+  } catch (error) {
+    console.warn('Suomidle: localStorage is unavailable; skipping legacy migration.', error)
+    return false
+  }
+}
+
+const waitForBody = async () => {
+  if (!hasDocumentSupport()) return
+  if (document.body) return
+  await new Promise<void>((resolve) => {
+    window.addEventListener(
+      'DOMContentLoaded',
+      () => {
+        resolve()
+      },
+      { once: true },
+    )
+  })
+}
+
+const writeLocalStorage = (key: string, value: string) => {
+  try {
+    window.localStorage.setItem(key, value)
+    return true
+  } catch (error) {
+    console.error(`Suomidle: failed to persist migrated value for "${key}".`, error)
+    return false
+  }
+}
+
+const markMigrationComplete = () => {
+  try {
+    window.localStorage.setItem(MIGRATION_STATE_KEY, MIGRATION_STATE_VALUE)
+  } catch (error) {
+    console.warn('Suomidle: unable to persist legacy migration marker.', error)
+  }
+}
+
+const hasMigrationCompleted = () => {
+  try {
+    return window.localStorage.getItem(MIGRATION_STATE_KEY) === MIGRATION_STATE_VALUE
+  } catch (error) {
+    console.warn('Suomidle: unable to read legacy migration marker.', error)
+    return false
+  }
+}
+
+const applyPayload = (payload: Record<string, unknown>): boolean => {
+  let imported = false
+  const keys = [GAME_STORAGE_KEY, SETTINGS_STORAGE_KEY]
+  for (const key of keys) {
+    const value = payload[key]
+    if (typeof value !== 'string') continue
+    const didWrite = writeLocalStorage(key, value)
+    imported = imported || didWrite
+  }
+  return imported
+}
+
+const buildRequestId = () => {
+  if (!hasWindowSupport()) return `${Date.now()}`
+  const cryptoApi = window.crypto
+  if (cryptoApi?.randomUUID) return cryptoApi.randomUUID()
+  return Math.random().toString(36).slice(2)
+}
+
+const setMigrationFrameAttributes = (frame: HTMLIFrameElement) => {
+  frame.setAttribute(MIGRATION_IFRAME_ATTRIBUTE, 'true')
+  frame.setAttribute('aria-hidden', 'true')
+  frame.style.display = 'none'
+  frame.tabIndex = -1
+}
+
+const resolveLegacyFrame = () =>
+  document.querySelector(`iframe[${MIGRATION_IFRAME_ATTRIBUTE}]`) as HTMLIFrameElement | null
+
+export const ensureLegacyStorageMigrated = async (
+  options?: LegacyMigrationOptions,
+): Promise<void> => {
+  if (!hasWindowSupport() || !hasDocumentSupport()) return
+  if (!hasLocalStorageSupport()) return
+  const hostname = options?.hostnameOverride ?? window.location.hostname
+  if (!options?.force && !MIGRATION_SUPPORTED_HOSTS.has(hostname)) return
+  if (resolveLegacyFrame()) return
+  if (!options?.force && hasMigrationCompleted()) return
+  await waitForBody()
+  const requestId = options?.requestIdOverride ?? buildRequestId()
+  await new Promise<void>((resolve) => {
+    let finished = false
+    const frame = document.createElement('iframe')
+    setMigrationFrameAttributes(frame)
+    const timeoutController = { id: 0 }
+    const cleanup = (markComplete: boolean) => {
+      if (finished) return
+      finished = true
+      window.clearTimeout(timeoutController.id)
+      window.removeEventListener('message', handleMessage)
+      frame.remove()
+      if (markComplete) {
+        markMigrationComplete()
+        console.info('Suomidle: migrated legacy save data from GitHub Pages origin.')
+      }
+      resolve()
+    }
+    const handleMessage = (event: MessageEvent<LegacyResponseMessage>) => {
+      if (event.origin !== LEGACY_ORIGIN) return
+      const message = event.data
+      if (!message || message.type !== RESPONSE_MESSAGE_TYPE) return
+      if (message.requestId && message.requestId !== requestId) return
+      if (message.status === 'error') {
+        if (message.error) {
+          console.error('Suomidle: legacy migration failed on remote origin.', message.error)
+        }
+        cleanup(false)
+        return
+      }
+      const payload = message.payload
+      const imported = payload && typeof payload === 'object' ? applyPayload(payload) : false
+      const shouldMarkComplete = imported || message.status === 'empty'
+      cleanup(shouldMarkComplete)
+    }
+    window.addEventListener('message', handleMessage)
+    frame.addEventListener(
+      'load',
+      () => {
+        const target = frame.contentWindow
+        if (!target) {
+          console.warn('Suomidle: legacy migration iframe has no contentWindow; aborting.')
+          cleanup(false)
+          return
+        }
+        try {
+          target.postMessage(
+            {
+              type: REQUEST_MESSAGE_TYPE,
+              requestId,
+            },
+            LEGACY_ORIGIN,
+          )
+        } catch (error) {
+          console.error('Suomidle: failed to request legacy save data.', error)
+          cleanup(false)
+        }
+      },
+      { once: true },
+    )
+    const timeout = options?.requestTimeoutMs ?? DEFAULT_TIMEOUT_MS
+    timeoutController.id = window.setTimeout(() => {
+      console.warn('Suomidle: timed out while waiting for legacy save data.')
+      cleanup(false)
+    }, timeout)
+    frame.src = `${LEGACY_ORIGIN}${LEGACY_MIGRATION_PATH}`
+    document.body.append(frame)
+  })
+}
+


### PR DESCRIPTION
## Summary
- add a legacy storage migration utility that pulls saves from the old GitHub Pages origin before the app bootstraps
- serve a migration proxy page that exposes the legacy localStorage via postMessage with basic origin checks
- cover the migration flow with Vitest cases and document the new behaviour in the changelog
- allow the migration to overwrite newer aaroonparas.com saves once while adding a hostname override that keeps the Vitest suite deterministic

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cac41404e083289f69ef8e086da862