### PR TITLE
Set page title to suomidle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,5 @@
 ## [Unreleased]
 ### Added
 - Configure deployments to publish the `aaroonparas.com` CNAME record.
+### Changed
+- Update the page title to display "suomidle" in browser tabs.

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>suomidle</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- set the base HTML title to "suomidle" so browser tabs show the correct game name
- record the title update in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cae6e668b08328872c61245aca377c