### PR TITLE
Remove decimals from Lämpötila counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Configure deployments to publish the `aaroonparas.com` CNAME record.
 ### Changed
 - Update the page title to display "suomidle" in browser tabs.
+- Remove decimals from the Lämpötila counter for clearer progress tracking.

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -9,7 +9,8 @@ export function HUD() {
   return (
     <div>
       <div className="hud hud__population">
-        Lämpötila: {formatNumber(population)} | LPS: {formatNumber(cps)}
+        Lämpötila: {formatNumber(population, { maximumFractionDigits: 0 })} | LPS:{' '}
+        {formatNumber(cps)}
       </div>
       <button
         className="btn btn--primary"

--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -9,4 +9,16 @@ describe('formatNumber', () => {
   it('formats numbers at or above 1e6 in scientific notation', () => {
     expect(formatNumber(1000000)).toBe('1.00e+6');
   });
+
+  it('removes decimals when requested', () => {
+    expect(formatNumber(1234.56, { maximumFractionDigits: 0 })).toBe('1,234');
+  });
+
+  it('truncates decimals instead of rounding when removing them', () => {
+    expect(formatNumber(1.99, { maximumFractionDigits: 0 })).toBe('1');
+  });
+
+  it('omits decimals in exponential notation when requested', () => {
+    expect(formatNumber(1000000, { maximumFractionDigits: 0 })).toBe('1e+6');
+  });
 });

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,6 +1,37 @@
-export function formatNumber(n: number): string {
-  if (Math.abs(n) < 1e6) {
-    return n.toLocaleString(undefined, { maximumFractionDigits: 2 });
+const EXPONENTIAL_THRESHOLD = 1_000_000;
+const MAX_FRACTION_DIGITS = 20;
+
+type FormatNumberOptions = {
+  maximumFractionDigits?: number;
+  exponentFractionDigits?: number;
+};
+
+const clampFractionDigits = (value: number | undefined, fallback: number) => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return fallback;
   }
-  return n.toExponential(2);
+  const integer = Math.trunc(value);
+  return Math.min(MAX_FRACTION_DIGITS, Math.max(0, integer));
+};
+
+const truncateIfNeeded = (value: number, shouldTruncate: boolean) =>
+  shouldTruncate ? Math.trunc(value) : value;
+
+export function formatNumber(n: number, options?: FormatNumberOptions): string {
+  const maximumFractionDigits = clampFractionDigits(
+    options?.maximumFractionDigits,
+    2,
+  );
+  const exponentFractionDigits = clampFractionDigits(
+    options?.exponentFractionDigits,
+    maximumFractionDigits,
+  );
+
+  if (Math.abs(n) < EXPONENTIAL_THRESHOLD) {
+    const value = truncateIfNeeded(n, maximumFractionDigits === 0);
+    return value.toLocaleString(undefined, { maximumFractionDigits });
+  }
+
+  const value = truncateIfNeeded(n, maximumFractionDigits === 0);
+  return value.toExponential(exponentFractionDigits);
 }


### PR DESCRIPTION
## Summary
- allow `formatNumber` to accept formatting options and support truncating fractional digits
- display the Lämpötila counter using whole numbers and add coverage for the new formatting behavior
- document the UI update in the changelog

## Testing
- npm test
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cae83e234483289d55ff3838e4be75