### PR TITLE
Fix GitHub Pages workflow root artifact assembly

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -77,7 +77,9 @@ jobs:
 
           # Root site
           if [ -d combined/_root ]; then
-            rsync -a --delete combined/_root/ combined/
+            # Remove stale root-level files while keeping the dev build intact
+            find combined -mindepth 1 -maxdepth 1 ! -name dev ! -name _root -exec rm -rf {} +
+            rsync -a combined/_root/ combined/
             rm -rf combined/_root
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,6 @@
 - Hide the Maailma shop until Polta Maailma has been used at least once.
 ### Changed
 - Update the page title to display "suomidle" in browser tabs.
+
+### Fixed
+- Prevent GitHub Pages deployments from failing when promoting the root build into the combined artifact.


### PR DESCRIPTION
## Summary
- remove the destructive rsync flags when promoting the root build into the combined Pages artifact
- clear stale root-level files while preserving the /dev build before copying
- document the deployment fix in the changelog

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caf2328f588328a9408ddcb20bc46e