### PR TITLE
Configure Vite base path via environment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,9 +3,14 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
+declare const process: { env?: Record<string, string | undefined> }
+
+const envBase = process?.env?.VITE_BASE ?? process?.env?.BASE_URL ?? '/'
+const base = envBase.endsWith('/') ? envBase : `${envBase}/`
+
 export default defineConfig({
   plugins: [react()],
-  base: '/',
+  base,
   // @ts-expect-error - Vitest config
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- read the Vite base path from VITE_BASE or BASE_URL environment variables with a trailing slash fallback
- default to the root path when no environment variables are set while preserving import.meta.env.BASE_URL

## Testing
- VITE_BASE=/dev/ npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb026689dc8328a47d8340d5a096e1