### PR TITLE
Add daily tasks system with buffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+- Daily Tasks system with rotating objectives, persistent progress, and temporary Lämpötila buffs.
 - Configure deployments to publish the `aaroonparas.com` CNAME record.
 - Collapsible controls for the building, technology, tier, and Maailma shops.
 - Automate GitHub Pages deployments for the main site and /dev/ preview with combined artifacts.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { playTierMusic } from './audio/music';
 import { useSettingsStore } from './app/settingsStore';
 import { MaailmaShop } from './ui/MaailmaShop';
 import { PoltaMaailmaButton } from './ui/PoltaMaailmaButton';
+import { DailyTasksPanel } from './ui/dailyTasksUI';
 
 function App() {
   const tierLevel = useGameStore((s) => s.tierLevel);
@@ -25,6 +26,9 @@ function App() {
   }, []);
   useEffect(() => {
     useGameStore.getState().recompute();
+  }, []);
+  useEffect(() => {
+    useGameStore.getState().initializeDailyTasks();
   }, []);
   useEffect(() => {
     const body = document.body;
@@ -55,6 +59,7 @@ function App() {
       )}
       <Settings />
       <HUD />
+      <DailyTasksPanel />
       <PrestigeCard />
       <BuildingsGrid />
       <TechGrid />

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -17,6 +17,17 @@ import {
   type PermanentBonuses,
 } from '../effects/applyPermanentBonuses';
 import maailmaShop from '../data/maailma_shop.json' assert { type: 'json' };
+import {
+  createInitialDailyTasksState,
+  syncDailyTasksState,
+  handleDailyTaskEvent,
+  applyUptimeProgress,
+  getEffectiveTemperatureMultiplier,
+  claimDailyTaskReward as claimDailyTaskRewardEffect,
+  type DailyTasksState,
+  type DailyTaskPlayerContext,
+  updateDailyTaskMetrics,
+} from '../systems/dailyTasks';
 
 export const BigBeautifulBalancePath = 7;
 let needsEraPrompt = false;
@@ -55,6 +66,7 @@ interface BaseState {
   lastMajorVersion: number;
   eraPromptAcknowledged: boolean;
   maailma: MaailmaState;
+  dailyTasks: DailyTasksState;
 }
 
 interface Actions {
@@ -76,6 +88,8 @@ interface Actions {
   };
   prestige: () => boolean;
   changeEra: () => void;
+  initializeDailyTasks: () => void;
+  claimDailyTaskReward: (taskId: string) => void;
 }
 
 type State = BaseState & Actions;
@@ -172,6 +186,17 @@ const createInitialMaailmaState = (): MaailmaState => ({
   era: 0,
 });
 
+const buildDailyTaskContext = (state: BaseState): DailyTaskPlayerContext => ({
+  tierLevel: state.tierLevel,
+  population: state.population,
+  totalPopulation: state.totalPopulation,
+  prestigeMult: state.prestigeMult,
+  prestigeUnlocked:
+    state.prestigePoints > 0 ||
+    state.prestigeMult > 1 ||
+    state.totalPopulation >= prestigeData.minPopulation,
+});
+
 const createInitialBaseState = (): BaseState => {
   const maailma = createInitialMaailmaState();
   const permanent = computePermanentBonusesFromMaailma(maailma);
@@ -194,6 +219,7 @@ const createInitialBaseState = (): BaseState => {
     lastMajorVersion: BigBeautifulBalancePath,
     eraPromptAcknowledged: true,
     maailma,
+    dailyTasks: createInitialDailyTasksState(),
   };
 };
 
@@ -203,14 +229,18 @@ const createProgressResetState = (state: State, maailmaOverride?: MaailmaState):
   const permanent = computePermanentBonusesFromMaailma(maailma);
   const prestigeMult = Math.max(base.prestigeMult, permanent.saunaPrestigeBaseMultiplierMin);
   const lampotilaRate = Math.max(0, permanent.lampotilaRateMult);
-  return {
+  const resetBase: BaseState = {
     ...base,
     eraMult: state.eraMult,
     maailma,
     modifiers: { ...(base.modifiers ?? { permanent }), permanent },
     prestigeMult,
     lampotilaRate,
+    dailyTasks: state.dailyTasks,
   };
+  const context = buildDailyTaskContext(resetBase);
+  const dailyTasks = syncDailyTasksState(state.dailyTasks, context, Date.now());
+  return { ...resetBase, dailyTasks };
 };
 
 const normalizeMaailma = (value: unknown): MaailmaState => {
@@ -331,13 +361,21 @@ const sanitizeState = (state: State): BaseState => {
   const permanent = computePermanentBonusesFromMaailma(maailma);
   const prestigeMult = Math.max(base.prestigeMult, permanent.saunaPrestigeBaseMultiplierMin);
   const previousModifiers = base.modifiers ?? { permanent };
-  return {
+  const sanitized: BaseState = {
     ...base,
     prestigeMult,
     lampotilaRate: permanent.lampotilaRateMult,
     modifiers: { ...previousModifiers, permanent },
     maailma,
   };
+  const now = Date.now();
+  const context = buildDailyTaskContext(sanitized);
+  const dailyTasks = syncDailyTasksState(
+    base.dailyTasks ?? createInitialDailyTasksState(),
+    context,
+    now,
+  );
+  return { ...sanitized, dailyTasks };
 };
 
 const buildPersistedData = (
@@ -413,59 +451,129 @@ export const useGameStore = create<State>()(
     (set, get) => ({
       ...createInitialBaseState(),
       addPopulation: (amount) =>
-        set((s) => ({
-          population: s.population + amount,
-          totalPopulation: s.totalPopulation + amount,
-        })),
+        set((s) => {
+          const now = Date.now();
+          const contextBefore = buildDailyTaskContext(s);
+          let dailyTasks = syncDailyTasksState(s.dailyTasks, contextBefore, now);
+          const { state: buffedTasks, multiplier } = getEffectiveTemperatureMultiplier(
+            dailyTasks,
+            now,
+          );
+          dailyTasks = buffedTasks;
+          const gain = amount * multiplier;
+          const nextPopulation = s.population + gain;
+          const nextTotalPopulation = s.totalPopulation + gain;
+          const contextAfter: DailyTaskPlayerContext = {
+            ...contextBefore,
+            population: nextPopulation,
+            totalPopulation: nextTotalPopulation,
+          };
+          dailyTasks = handleDailyTaskEvent(dailyTasks, { type: 'loyly_throw' }, contextAfter, now);
+          dailyTasks = handleDailyTaskEvent(dailyTasks, { type: 'click' }, contextAfter, now);
+          return {
+            population: nextPopulation,
+            totalPopulation: nextTotalPopulation,
+            dailyTasks,
+          };
+        }),
       purchaseBuilding: (id) => {
         const b = getBuilding(id);
         if (!b) return;
-        const s = get();
-        const permanent = s.modifiers.permanent;
-        const tierOffset = Math.trunc(permanent.tierUnlockOffset);
-        const effectiveTierLevel = s.tierLevel - tierOffset;
-        if (b.unlock?.tier && effectiveTierLevel < b.unlock.tier) return;
-        const count = s.buildings[id] || 0;
-        const baseCostMult = b.costMult + permanent.buildingCostMultiplier.delta;
-        const floor = permanent.buildingCostMultiplier.floor;
-        const adjustedMult =
-          typeof floor === 'number' && Number.isFinite(floor)
-            ? Math.max(baseCostMult, floor)
-            : baseCostMult;
-        const costMult = Math.max(0.0001, adjustedMult);
-        const price = b.baseCost * Math.pow(costMult, count);
-        if (s.population < price) return;
-        set({
-          population: s.population - price,
-          buildings: { ...s.buildings, [id]: count + 1 },
+        let didPurchase = false;
+        set((s) => {
+          const permanent = s.modifiers.permanent;
+          const tierOffset = Math.trunc(permanent.tierUnlockOffset);
+          const effectiveTierLevel = s.tierLevel - tierOffset;
+          if (b.unlock?.tier && effectiveTierLevel < b.unlock.tier) return {};
+          const count = s.buildings[id] || 0;
+          const baseCostMult = b.costMult + permanent.buildingCostMultiplier.delta;
+          const floor = permanent.buildingCostMultiplier.floor;
+          const adjustedMult =
+            typeof floor === 'number' && Number.isFinite(floor)
+              ? Math.max(baseCostMult, floor)
+              : baseCostMult;
+          const costMult = Math.max(0.0001, adjustedMult);
+          const price = b.baseCost * Math.pow(costMult, count);
+          if (s.population < price) return {};
+          const now = Date.now();
+          const contextBefore = buildDailyTaskContext(s);
+          let dailyTasks = syncDailyTasksState(s.dailyTasks, contextBefore, now);
+          const nextPopulation = s.population - price;
+          const buildings = { ...s.buildings, [id]: count + 1 };
+          const contextAfter: DailyTaskPlayerContext = {
+            ...contextBefore,
+            population: nextPopulation,
+          };
+          dailyTasks = updateDailyTaskMetrics(dailyTasks, contextAfter, now);
+          dailyTasks = handleDailyTaskEvent(
+            dailyTasks,
+            { type: 'building_bought', buildingId: id },
+            contextAfter,
+            now,
+          );
+          dailyTasks = handleDailyTaskEvent(
+            dailyTasks,
+            { type: 'building_bought_same_type', buildingId: id },
+            contextAfter,
+            now,
+          );
+          didPurchase = true;
+          return {
+            population: nextPopulation,
+            buildings,
+            dailyTasks,
+          };
         });
-        get().recompute();
+        if (didPurchase) {
+          get().recompute();
+        }
       },
       purchaseTech: (id) => {
         const t = getTech(id);
         if (!t) return;
-        const s = get();
-        const count = s.techCounts[id] || 0;
-        const limit = t.limit ?? 1;
-        if (count >= limit) return;
-        const tierOffset = Math.trunc(s.modifiers.permanent.tierUnlockOffset);
-        const effectiveTierLevel = s.tierLevel - tierOffset;
-        if (t.unlock?.tier && effectiveTierLevel < t.unlock.tier) return;
-        if (s.population < t.cost) return;
-        const nextCounts = { ...s.techCounts, [id]: count + 1 };
-        const multipliers = { ...s.multipliers };
-        for (const eff of t.effects) {
-          if (eff.target === 'population_cps') {
-            if (eff.type === 'mult') multipliers.population_cps *= eff.value;
-            else multipliers.population_cps += eff.value;
+        let didPurchase = false;
+        set((s) => {
+          const count = s.techCounts[id] || 0;
+          const limit = t.limit ?? 1;
+          if (count >= limit) return {};
+          const tierOffset = Math.trunc(s.modifiers.permanent.tierUnlockOffset);
+          const effectiveTierLevel = s.tierLevel - tierOffset;
+          if (t.unlock?.tier && effectiveTierLevel < t.unlock.tier) return {};
+          if (s.population < t.cost) return {};
+          const nextCounts = { ...s.techCounts, [id]: count + 1 };
+          const multipliers = { ...s.multipliers };
+          for (const eff of t.effects) {
+            if (eff.target === 'population_cps') {
+              if (eff.type === 'mult') multipliers.population_cps *= eff.value;
+              else multipliers.population_cps += eff.value;
+            }
           }
-        }
-        set({
-          population: s.population - t.cost,
-          techCounts: nextCounts,
-          multipliers,
+          const now = Date.now();
+          const contextBefore = buildDailyTaskContext(s);
+          let dailyTasks = syncDailyTasksState(s.dailyTasks, contextBefore, now);
+          const nextPopulation = s.population - t.cost;
+          const contextAfter: DailyTaskPlayerContext = {
+            ...contextBefore,
+            population: nextPopulation,
+          };
+          dailyTasks = updateDailyTaskMetrics(dailyTasks, contextAfter, now);
+          dailyTasks = handleDailyTaskEvent(
+            dailyTasks,
+            { type: 'technology_bought', technologyId: id },
+            contextAfter,
+            now,
+          );
+          didPurchase = true;
+          return {
+            population: nextPopulation,
+            techCounts: nextCounts,
+            multipliers,
+            dailyTasks,
+          };
         });
-        get().recompute();
+        if (didPurchase) {
+          get().recompute();
+        }
       },
       purchaseMaailmaUpgrade: (id) => {
         let didPurchase = false;
@@ -531,14 +639,36 @@ export const useGameStore = create<State>()(
         set({ cps, clickPower, lampotilaRate: Math.max(0, permanent.lampotilaRateMult) });
       },
       tick: (delta, options) => {
-        const state = get();
-        const offlineMult = options?.offline ? state.modifiers.permanent.offlineProdMult : 1;
-        const gain = state.cps * delta * offlineMult;
-        if (gain > 0)
-          set((s) => ({
-            population: s.population + gain,
-            totalPopulation: s.totalPopulation + gain,
-          }));
+        set((s) => {
+          const now = Date.now();
+          const contextBefore = buildDailyTaskContext(s);
+          let dailyTasks = syncDailyTasksState(s.dailyTasks, contextBefore, now);
+          const { state: buffedTasks, multiplier } = getEffectiveTemperatureMultiplier(
+            dailyTasks,
+            now,
+          );
+          dailyTasks = buffedTasks;
+          const offlineMult = options?.offline ? s.modifiers.permanent.offlineProdMult : 1;
+          const gain = s.cps * delta * offlineMult * multiplier;
+          let nextPopulation = s.population;
+          let nextTotalPopulation = s.totalPopulation;
+          if (gain > 0) {
+            nextPopulation += gain;
+            nextTotalPopulation += gain;
+          }
+          const contextAfter: DailyTaskPlayerContext = {
+            ...contextBefore,
+            population: nextPopulation,
+            totalPopulation: nextTotalPopulation,
+          };
+          dailyTasks = updateDailyTaskMetrics(dailyTasks, contextAfter, now);
+          dailyTasks = applyUptimeProgress(dailyTasks, contextAfter, delta, now, options);
+          return {
+            population: nextPopulation,
+            totalPopulation: nextTotalPopulation,
+            dailyTasks,
+          };
+        });
       },
       canAdvanceTier: () => {
         const s = get();
@@ -549,7 +679,20 @@ export const useGameStore = create<State>()(
       },
       advanceTier: () => {
         if (!get().canAdvanceTier()) return;
-        set((s) => ({ tierLevel: s.tierLevel + 1 }));
+        const now = Date.now();
+        set((s) => {
+          const nextTier = s.tierLevel + 1;
+          const contextBefore = buildDailyTaskContext(s);
+          let dailyTasks = syncDailyTasksState(s.dailyTasks, contextBefore, now);
+          const contextAfter: DailyTaskPlayerContext = { ...contextBefore, tierLevel: nextTier };
+          dailyTasks = handleDailyTaskEvent(
+            dailyTasks,
+            { type: 'tier_unlocked', tierLevel: nextTier },
+            contextAfter,
+            now,
+          );
+          return { tierLevel: nextTier, dailyTasks };
+        });
         get().recompute();
       },
       canPrestige: () => get().totalPopulation >= prestigeData.minPopulation,
@@ -576,6 +719,9 @@ export const useGameStore = create<State>()(
       prestige: () => {
         if (!get().canPrestige()) return false;
         const s = get();
+        const now = Date.now();
+        const contextBefore = buildDailyTaskContext(s);
+        let dailyTasks = syncDailyTasksState(s.dailyTasks, contextBefore, now);
         const pointsAfter = computePrestigePoints(s.totalPopulation);
         const normalizedMaailma = normalizeMaailma(s.maailma);
         const permanent = computePermanentBonusesFromMaailma(normalizedMaailma);
@@ -585,7 +731,7 @@ export const useGameStore = create<State>()(
         const preservedMultipliers = keepTech ? { ...s.multipliers } : baseState.multipliers;
         const multAfterRaw = computePrestigeMult(pointsAfter);
         const multAfter = Math.max(multAfterRaw, permanent.saunaPrestigeBaseMultiplierMin);
-        set({
+        const resetState: BaseState = {
           ...baseState,
           multipliers: preservedMultipliers,
           techCounts: preservedTechCounts,
@@ -596,6 +742,14 @@ export const useGameStore = create<State>()(
           maailma: normalizedMaailma,
           modifiers: { ...baseState.modifiers, permanent },
           lampotilaRate: Math.max(0, permanent.lampotilaRateMult),
+          dailyTasks,
+        };
+        const contextAfter = buildDailyTaskContext(resetState);
+        dailyTasks = syncDailyTasksState(dailyTasks, contextAfter, now);
+        dailyTasks = handleDailyTaskEvent(dailyTasks, { type: 'prestige' }, contextAfter, now);
+        set({
+          ...resetState,
+          dailyTasks,
         });
         get().recompute();
         saveGame();
@@ -603,12 +757,16 @@ export const useGameStore = create<State>()(
       },
       changeEra: () => {
         const s = get();
+        const now = Date.now();
+        const contextBefore = buildDailyTaskContext(s);
+        let dailyTasks = syncDailyTasksState(s.dailyTasks, contextBefore, now);
         const normalizedMaailma = normalizeMaailma(s.maailma);
         const permanent = computePermanentBonusesFromMaailma(normalizedMaailma);
         const baseState = createInitialBaseState();
-        set({
+        const nextEraMult = s.eraMult + 1;
+        const resetState: BaseState = {
           ...baseState,
-          eraMult: s.eraMult + 1,
+          eraMult: nextEraMult,
           maailma: normalizedMaailma,
           modifiers: { ...baseState.modifiers, permanent },
           prestigeMult: Math.max(
@@ -616,9 +774,33 @@ export const useGameStore = create<State>()(
             permanent.saunaPrestigeBaseMultiplierMin,
           ),
           lampotilaRate: Math.max(0, permanent.lampotilaRateMult),
+          dailyTasks,
+        };
+        const contextAfter = buildDailyTaskContext(resetState);
+        dailyTasks = syncDailyTasksState(dailyTasks, contextAfter, now);
+        set({
+          ...resetState,
+          dailyTasks,
         });
         get().recompute();
         saveGame();
+      },
+      initializeDailyTasks: () => {
+        const now = Date.now();
+        set((s) => {
+          const context = buildDailyTaskContext(s);
+          const dailyTasks = syncDailyTasksState(s.dailyTasks, context, now);
+          return { dailyTasks };
+        });
+      },
+      claimDailyTaskReward: (taskId) => {
+        const now = Date.now();
+        set((s) => {
+          const context = buildDailyTaskContext(s);
+          const synced = syncDailyTasksState(s.dailyTasks, context, now);
+          const { state: nextTasks } = claimDailyTaskRewardEffect(synced, taskId, now);
+          return { dailyTasks: nextTasks };
+        });
       },
     }),
     {
@@ -668,6 +850,7 @@ export const useGameStore = create<State>()(
             maailma,
             modifiers: { permanent },
             lampotilaRate: Math.max(0, permanent.lampotilaRateMult),
+            dailyTasks: createInitialDailyTasksState(),
           };
         }
 
@@ -700,6 +883,7 @@ export const useGameStore = create<State>()(
             maailma,
             modifiers: { permanent },
             lampotilaRate: Math.max(0, permanent.lampotilaRateMult),
+            dailyTasks: createInitialDailyTasksState(),
           };
         }
 
@@ -768,6 +952,7 @@ export const useGameStore = create<State>()(
           maailma,
           modifiers: { permanent },
           lampotilaRate: Math.max(0, permanent.lampotilaRateMult),
+          dailyTasks: createInitialDailyTasksState(),
         };
       },
       onRehydrateStorage: () => (state) => {
@@ -786,6 +971,7 @@ export const useGameStore = create<State>()(
         state.recompute();
         const delta = Math.max(0, Math.floor((now - last) / 1000));
         state.tick(delta, { offline: true });
+        state.initializeDailyTasks();
         useGameStore.setState({ lastSave: now, maailma: normalizedMaailma });
         let acknowledged = state.eraPromptAcknowledged;
         try {

--- a/src/data/daily_tasks.json
+++ b/src/data/daily_tasks.json
@@ -1,0 +1,237 @@
+{
+  "version": 1,
+  "reset_timezone": "Europe/Helsinki",
+  "daily_rotation": {
+    "tasks_per_day": 3,
+    "allow_duplicates_same_day": false,
+    "reroll_cost_population": 0,
+    "reroll_limit_per_day": 1,
+    "selection": {
+      "use_weights": true,
+      "min_tier": 0,
+      "max_active_per_category": 1
+    }
+  },
+  "reward_templates": {
+    "small_temp_boost": { "type": "temp_gain_mult", "value": 0.15, "duration_s": 600, "cooldown_s": 0 },
+    "medium_temp_boost": { "type": "temp_gain_mult", "value": 0.25, "duration_s": 900, "cooldown_s": 0 },
+    "large_temp_boost": { "type": "temp_gain_mult", "value": 0.40, "duration_s": 1200, "cooldown_s": 0 }
+  },
+  "tasks": [
+    {
+      "id": "loyly_100",
+      "title_fi": "Heitä löylyä 100 kertaa",
+      "desc_fi": "Heitä yhteensä 100 löylyä tänään.",
+      "category": "actions",
+      "condition": { "type": "counter", "event": "loyly_throw", "target": 100 },
+      "reward": "small_temp_boost",
+      "weight": 10,
+      "min_tier": 0,
+      "max_per_day": 1
+    },
+    {
+      "id": "loyly_250",
+      "title_fi": "Heitä löylyä 250 kertaa",
+      "desc_fi": "Heitä yhteensä 250 löylyä tänään.",
+      "category": "actions",
+      "condition": { "type": "counter", "event": "loyly_throw", "target": 250 },
+      "reward": "medium_temp_boost",
+      "weight": 7,
+      "min_tier": 1,
+      "max_per_day": 1
+    },
+    {
+      "id": "loyly_500",
+      "title_fi": "Heitä löylyä 500 kertaa",
+      "desc_fi": "Heitä yhteensä 500 löylyä tänään.",
+      "category": "actions",
+      "condition": { "type": "counter", "event": "loyly_throw", "target": 500 },
+      "reward": "large_temp_boost",
+      "weight": 4,
+      "min_tier": 2,
+      "max_per_day": 1
+    },
+    {
+      "id": "buy_building_1",
+      "title_fi": "Osta 1 uusi rakennus",
+      "desc_fi": "Osta mikä tahansa uusi rakennus.",
+      "category": "economy",
+      "condition": { "type": "counter", "event": "building_bought", "target": 1 },
+      "reward": "small_temp_boost",
+      "weight": 9,
+      "min_tier": 0,
+      "max_per_day": 1
+    },
+    {
+      "id": "buy_building_10",
+      "title_fi": "Osta 10 rakennusta",
+      "desc_fi": "Osta yhteensä 10 rakennusta tänään.",
+      "category": "economy",
+      "condition": { "type": "counter", "event": "building_bought", "target": 10 },
+      "reward": "medium_temp_boost",
+      "weight": 6,
+      "min_tier": 1,
+      "max_per_day": 1
+    },
+    {
+      "id": "buy_tech_1",
+      "title_fi": "Osta yksi uusi teknologia",
+      "desc_fi": "Hanki tänään yksi uusi teknologia.",
+      "category": "tech",
+      "condition": { "type": "counter", "event": "technology_bought", "target": 1 },
+      "reward": "medium_temp_boost",
+      "weight": 8,
+      "min_tier": 0,
+      "max_per_day": 1
+    },
+    {
+      "id": "reach_temp_1e6",
+      "title_fi": "Saavuta 1e6 lämpötila",
+      "desc_fi": "Nosta lämpötila vähintään arvoon 1e6 tänään.",
+      "category": "milestone",
+      "condition": { "type": "threshold", "metric": "temperature", "target": "1e6" },
+      "reward": "small_temp_boost",
+      "weight": 8,
+      "min_tier": 0,
+      "max_per_day": 1
+    },
+    {
+      "id": "reach_temp_1e10",
+      "title_fi": "Saavuta 1e9 lämpötila",
+      "desc_fi": "Nosta lämpötila vähintään arvoon 1e9 tänään.",
+      "category": "milestone",
+      "condition": { "type": "threshold", "metric": "temperature", "target": "1e9" },
+      "reward": "medium_temp_boost",
+      "weight": 6,
+      "min_tier": 1,
+      "max_per_day": 1
+    },
+    {
+      "id": "reach_temp_1e16",
+      "title_fi": "Saavuta 1e12 lämpötila",
+      "desc_fi": "Nosta lämpötila vähintään arvoon 1e12 tänään.",
+      "category": "milestone",
+      "condition": { "type": "threshold", "metric": "temperature", "target": "1e12" },
+      "reward": "large_temp_boost",
+      "weight": 4,
+      "min_tier": 2,
+      "max_per_day": 1
+    },
+    {
+      "id": "combo_streak_60s",
+      "title_fi": "Löylyputki 60 s",
+      "desc_fi": "Pidä löylyputki yllä 60 sekuntia (heittoja ilman yli 2 s taukoa).",
+      "category": "skill",
+      "condition": { "type": "streak", "event": "loyly_throw", "window_s": 60, "max_gap_s": 2 },
+      "reward": "medium_temp_boost",
+      "weight": 5,
+      "min_tier": 1,
+      "max_per_day": 1
+    },
+    {
+      "id": "prestige_once",
+      "title_fi": "Polta sauna kerran",
+      "desc_fi": "Käytä Polta sauna tänään vähintään kerran.",
+      "category": "prestige",
+      "condition": { "type": "counter", "event": "prestige", "target": 1 },
+      "reward": "large_temp_boost",
+      "weight": 3,
+      "min_tier": 2,
+      "requires_feature": "prestige",
+      "max_per_day": 1
+    },
+    {
+      "id": "increase_prestige_mult",
+      "title_fi": "Kasvata polta sauna -kerrointa",
+      "desc_fi": "Nosta pysyvää kerrointa vähintään +1 tänään.",
+      "category": "prestige",
+      "condition": { "type": "delta_threshold", "metric": "prestige_multiplier", "delta": 1 },
+      "reward": "large_temp_boost",
+      "weight": 2,
+      "min_tier": 3,
+      "requires_feature": "prestige",
+      "max_per_day": 1
+    },
+    {
+      "id": "upgrade_same_building_3",
+      "title_fi": "Päivitä samaa rakennusta 3 kertaa",
+      "desc_fi": "Tee kolme ostoa samaan rakennukseen tänään.",
+      "category": "economy",
+      "condition": { "type": "counter", "event": "building_bought_same_type", "target": 3 },
+      "reward": "small_temp_boost",
+      "weight": 6,
+      "min_tier": 0,
+      "max_per_day": 1
+    },
+    {
+      "id": "unlock_next_tier",
+      "title_fi": "Avaa seuraava taso",
+      "desc_fi": "Etene seuraavaan tieriin tänään.",
+      "category": "progression",
+      "condition": { "type": "counter", "event": "tier_unlocked", "target": 1 },
+      "reward": "medium_temp_boost",
+      "weight": 4,
+      "min_tier": 1,
+      "max_per_day": 1
+    },
+    {
+      "id": "earn_population_today",
+      "title_fi": "Ansaitse 1e7 lämpötilaa tänään",
+      "desc_fi": "Kasvata päivän netto-lämpöä vähintään 1e7.",
+      "category": "economy",
+      "condition": { "type": "delta_threshold", "metric": "population_earned_today", "target": "1e7" },
+      "reward": "medium_temp_boost",
+      "weight": 6,
+      "min_tier": 1,
+      "max_per_day": 1
+    },
+    {
+      "id": "clicks_1000",
+      "title_fi": "Tee 1000 klikkausta",
+      "desc_fi": "Klikkaa yhteensä 1000 kertaa tänään.",
+      "category": "actions",
+      "condition": { "type": "counter", "event": "click", "target": 1000 },
+      "reward": "large_temp_boost",
+      "weight": 3,
+      "min_tier": 2,
+      "max_per_day": 1
+    },
+    {
+      "id": "session_10min",
+      "title_fi": "Saunavuoro 10 minuuttia",
+      "desc_fi": "Pidä peli auki yhtäjaksoisesti 10 minuuttia.",
+      "category": "time",
+      "condition": { "type": "uptime", "target_s": 600 },
+      "reward": "small_temp_boost",
+      "weight": 8,
+      "min_tier": 0,
+      "max_per_day": 1
+    },
+    {
+      "id": "fast_casts_5",
+      "title_fi": "Nopeat heitot ×5",
+      "desc_fi": "Tee 5 peräkkäistä löylynheittoa alle 1 s välein.",
+      "category": "skill",
+      "condition": { "type": "streak_rate", "event": "loyly_throw", "count": 5, "max_interval_s": 1.0 },
+      "reward": "small_temp_boost",
+      "weight": 6,
+      "min_tier": 0,
+      "max_per_day": 1
+    }
+  ],
+  "ui_texts_fi": {
+    "daily_tasks_title": "Päivän tehtävät",
+    "completed": "Valmis",
+    "claim_reward": "Lunasta tarjous",
+    "reward_active": "Päivitys aktiivinen",
+    "reward_expired": "Päivitys päättynyt",
+    "resets_in": "Uusiutuu",
+    "progress": "Edistyminen",
+    "of": "/"
+  },
+  "telemetry": {
+    "log_task_rolls": true,
+    "log_claims": true,
+    "log_buff_start_end": true
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -58,6 +58,21 @@ h1 {
   color: var(--color-button-text);
 }
 
+.btn--success {
+  background-color: #2f9e44;
+  color: var(--color-button-text);
+}
+
+.btn--disabled {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.55);
+  cursor: not-allowed;
+}
+
+.btn--disabled:disabled {
+  opacity: 0.75;
+}
+
 .btn--primary:hover,
 .btn--primary:active,
 .btn--primary:focus-visible {

--- a/src/systems/__tests__/dailyTasks.test.ts
+++ b/src/systems/__tests__/dailyTasks.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createInitialDailyTasksState,
+  ensureDailyTasksForToday,
+  getDailyTaskDefinition,
+  updateDailyTaskMetrics,
+  handleDailyTaskEvent,
+  claimDailyTaskReward as claimDailyTaskRewardEffect,
+  type DailyTasksState,
+  type DailyTaskPlayerContext,
+} from '../dailyTasks';
+
+const mockContext = (overrides?: Partial<DailyTaskPlayerContext>): DailyTaskPlayerContext => ({
+  tierLevel: 1,
+  population: 0,
+  totalPopulation: 0,
+  prestigeMult: 1,
+  prestigeUnlocked: false,
+  ...overrides,
+});
+
+describe('dailyTasks selection', () => {
+  it('filters tasks by tier and feature availability', () => {
+    const now = Date.UTC(2024, 0, 1);
+    const initial = createInitialDailyTasksState();
+    const context = mockContext();
+    const state = ensureDailyTasksForToday(initial, context, now, () => () => 0);
+    expect(state.taskOrder.length).toBeGreaterThan(0);
+    for (const id of state.taskOrder) {
+      const definition = getDailyTaskDefinition(id);
+      expect(definition).toBeDefined();
+      if (!definition) continue;
+      expect(definition.min_tier).toBeLessThanOrEqual(context.tierLevel - 1);
+      expect(definition.requires_feature).not.toBe('prestige');
+    }
+  });
+
+  it('respects category cap when rolling tasks', () => {
+    const now = Date.UTC(2024, 0, 2);
+    const context = mockContext({ tierLevel: 5, prestigeUnlocked: true });
+    const state = ensureDailyTasksForToday(createInitialDailyTasksState(), context, now, () => () => 0.1);
+    const categories = state.taskOrder
+      .map((id) => getDailyTaskDefinition(id)?.category)
+      .filter((value): value is string => typeof value === 'string');
+    const unique = new Set(categories);
+    expect(unique.size).toBe(categories.length);
+  });
+});
+
+describe('dailyTasks progression', () => {
+  it('completes streak tasks when conditions are met', () => {
+    const now = Date.now();
+    const state: DailyTasksState = {
+      ...createInitialDailyTasksState(),
+      rolledDate: '2024-01-01',
+      nextResetAt: now + 86_400_000,
+      taskOrder: ['combo_streak_60s'],
+      tasks: {
+        combo_streak_60s: {
+          id: 'combo_streak_60s',
+          rolledAt: '2024-01-01',
+          progress: 0,
+          completedAt: null,
+          claimedAt: null,
+          conditionState: { type: 'streak', events: [] },
+        },
+      },
+      metrics: {
+        baselines: { temperature: 0, population_earned_today: 0, prestige_multiplier: 1 },
+        current: { temperature: 0, population_earned_today: 0, prestige_multiplier: 1 },
+        uptimeSeconds: 0,
+        lastUptimeUpdate: null,
+      },
+      activeBuffs: [],
+      rerollsUsed: 0,
+    };
+    const context = mockContext({ tierLevel: 3, prestigeUnlocked: true });
+    let nextState = updateDailyTaskMetrics(state, context, now);
+    for (let i = 0; i <= 60; i += 1) {
+      nextState = handleDailyTaskEvent(nextState, { type: 'loyly_throw' }, context, now + i * 1000);
+    }
+    const task = nextState.tasks['combo_streak_60s'];
+    expect(task.completedAt).not.toBeNull();
+    expect(task.progress).toBeGreaterThanOrEqual(60);
+  });
+
+  it('only claims reward once', () => {
+    const now = Date.now();
+    const state: DailyTasksState = {
+      ...createInitialDailyTasksState(),
+      rolledDate: '2024-01-01',
+      nextResetAt: now + 86_400_000,
+      taskOrder: ['loyly_100'],
+      tasks: {
+        loyly_100: {
+          id: 'loyly_100',
+          rolledAt: '2024-01-01',
+          progress: 100,
+          completedAt: now - 1000,
+          claimedAt: null,
+          conditionState: { type: 'counter', count: 100 },
+        },
+      },
+      metrics: {
+        baselines: { temperature: 0, population_earned_today: 0, prestige_multiplier: 1 },
+        current: { temperature: 0, population_earned_today: 0, prestige_multiplier: 1 },
+        uptimeSeconds: 0,
+        lastUptimeUpdate: null,
+      },
+      activeBuffs: [],
+      rerollsUsed: 0,
+    };
+    const context = mockContext({ tierLevel: 2 });
+    const prepared = updateDailyTaskMetrics(state, context, now);
+    const first = claimDailyTaskRewardEffect(prepared, 'loyly_100', now);
+    expect(first.buff).not.toBeNull();
+    expect(first.state.tasks['loyly_100'].claimedAt).not.toBeNull();
+    const second = claimDailyTaskRewardEffect(first.state, 'loyly_100', now + 1000);
+    expect(second.buff).toBeNull();
+    expect(second.state.tasks['loyly_100'].claimedAt).toEqual(
+      first.state.tasks['loyly_100'].claimedAt,
+    );
+  });
+});

--- a/src/systems/dailyTasks.ts
+++ b/src/systems/dailyTasks.ts
@@ -1,0 +1,1065 @@
+import dailyTasksData from '../data/daily_tasks.json' assert { type: 'json' };
+import { telemetry } from '../telemetry';
+
+export interface DailyTaskRewardTemplate {
+  type: 'temp_gain_mult';
+  value: number;
+  duration_s: number;
+  cooldown_s: number;
+}
+
+export type DailyTaskCondition =
+  | { type: 'counter'; event: string; target: number }
+  | { type: 'threshold'; metric: string; target: number }
+  | { type: 'delta_threshold'; metric: string; target: number; delta?: number }
+  | { type: 'streak'; event: string; window_s: number; max_gap_s: number }
+  | { type: 'streak_rate'; event: string; count: number; max_interval_s: number }
+  | { type: 'sequence'; events: string[]; window_s?: number }
+  | { type: 'uptime'; target_s: number };
+
+export interface DailyTaskDefinition {
+  id: string;
+  title_fi: string;
+  desc_fi: string;
+  category: string;
+  condition: DailyTaskCondition;
+  reward: string;
+  weight: number;
+  min_tier: number;
+  max_per_day: number;
+  requires_feature?: string;
+}
+
+interface DailyTasksSelectionConfig {
+  tasks_per_day: number;
+  allow_duplicates_same_day: boolean;
+  reroll_cost_population: number;
+  reroll_limit_per_day: number;
+  selection: {
+    use_weights: boolean;
+    min_tier: number;
+    max_active_per_category: number;
+  };
+}
+
+interface DailyTasksTelemetryConfig {
+  log_task_rolls?: boolean;
+  log_completions?: boolean;
+  log_claims?: boolean;
+  log_buff_start_end?: boolean;
+}
+
+export interface DailyTasksConfig {
+  version: number;
+  reset_timezone: string;
+  daily_rotation: DailyTasksSelectionConfig;
+  reward_templates: Record<string, DailyTaskRewardTemplate>;
+  tasks: DailyTaskDefinition[];
+  ui_texts_fi: Record<string, string>;
+  telemetry?: DailyTasksTelemetryConfig;
+}
+
+export interface DailyTaskCounterState {
+  type: 'counter';
+  count: number;
+  byKey?: Record<string, number>;
+}
+
+export interface DailyTaskStreakState {
+  type: 'streak';
+  events: number[];
+}
+
+export interface DailyTaskStreakRateState {
+  type: 'streak_rate';
+  lastTimestamp: number | null;
+  count: number;
+}
+
+export interface DailyTaskSequenceState {
+  type: 'sequence';
+  index: number;
+  lastEventTime: number | null;
+}
+
+export interface DailyTaskUptimeState {
+  type: 'uptime';
+}
+
+export type DailyTaskConditionState =
+  | DailyTaskCounterState
+  | DailyTaskStreakState
+  | DailyTaskStreakRateState
+  | DailyTaskSequenceState
+  | DailyTaskUptimeState;
+
+export interface DailyTaskInstanceState {
+  id: string;
+  rolledAt: string;
+  progress: number;
+  completedAt: number | null;
+  claimedAt: number | null;
+  conditionState?: DailyTaskConditionState;
+}
+
+export interface DailyTaskBuff {
+  taskId: string;
+  rewardId: string;
+  type: 'temp_gain_mult';
+  value: number;
+  endsAt: number;
+}
+
+export interface DailyTaskMetricsState {
+  baselines: Record<string, number>;
+  current: Record<string, number>;
+  uptimeSeconds: number;
+  lastUptimeUpdate: number | null;
+}
+
+export interface DailyTaskToastDetail {
+  type: 'complete' | 'claim' | 'buff_expired';
+  taskId: string;
+  taskTitle: string;
+  rewardValue?: number;
+  rewardDuration?: number;
+}
+
+export const DAILY_TASK_TOAST_EVENT = 'daily-task-toast';
+
+const createToastEvent = (detail: DailyTaskToastDetail) => {
+  if (typeof CustomEvent === 'function') {
+    return new CustomEvent(DAILY_TASK_TOAST_EVENT, { detail });
+  }
+  const event = new Event(DAILY_TASK_TOAST_EVENT) as CustomEvent<DailyTaskToastDetail>;
+  Object.defineProperty(event, 'detail', { value: detail });
+  return event;
+};
+
+export const dailyTaskEventTarget = new EventTarget();
+
+const dispatchToast = (detail: DailyTaskToastDetail) => {
+  try {
+    dailyTaskEventTarget.dispatchEvent(createToastEvent(detail));
+  } catch {
+    // Ignore errors from dispatching toast events.
+  }
+};
+
+export interface DailyTasksState {
+  rolledDate: string | null;
+  taskOrder: string[];
+  tasks: Record<string, DailyTaskInstanceState>;
+  activeBuffs: DailyTaskBuff[];
+  metrics: DailyTaskMetricsState;
+  nextResetAt: number | null;
+  rerollsUsed: number;
+}
+
+export interface DailyTaskPlayerContext {
+  tierLevel: number;
+  population: number;
+  totalPopulation: number;
+  prestigeMult: number;
+  prestigeUnlocked: boolean;
+}
+
+export type DailyTaskEvent =
+  | { type: 'loyly_throw' }
+  | { type: 'click' }
+  | { type: 'building_bought'; buildingId: string }
+  | { type: 'building_bought_same_type'; buildingId: string }
+  | { type: 'technology_bought'; technologyId: string }
+  | { type: 'tier_unlocked'; tierLevel: number }
+  | { type: 'prestige' }
+  | { type: string; [key: string]: unknown };
+
+interface RollResult {
+  taskOrder: string[];
+  tasks: Record<string, DailyTaskInstanceState>;
+}
+
+const normalizeNumber = (value: unknown, fallback = 0): number => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed === '') return fallback;
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+  return fallback;
+};
+
+const normalizeCondition = (condition: unknown): DailyTaskCondition => {
+  if (!condition || typeof condition !== 'object') {
+    return { type: 'counter', event: 'noop', target: 1 };
+  }
+  const source = condition as Record<string, unknown>;
+  const type = typeof source.type === 'string' ? source.type : 'counter';
+  switch (type) {
+    case 'counter': {
+      const event = typeof source.event === 'string' ? source.event : 'noop';
+      const target = normalizeNumber(source.target, 1);
+      return { type: 'counter', event, target };
+    }
+    case 'threshold': {
+      const metric = typeof source.metric === 'string' ? source.metric : 'temperature';
+      const target = normalizeNumber(source.target, 0);
+      return { type: 'threshold', metric, target };
+    }
+    case 'delta_threshold': {
+      const metric = typeof source.metric === 'string' ? source.metric : 'temperature';
+      const target = normalizeNumber(source.target ?? source.delta, 0);
+      return { type: 'delta_threshold', metric, target };
+    }
+    case 'streak': {
+      const event = typeof source.event === 'string' ? source.event : 'noop';
+      const window_s = normalizeNumber(source.window_s, 1);
+      const max_gap_s = normalizeNumber(source.max_gap_s, window_s);
+      return { type: 'streak', event, window_s, max_gap_s };
+    }
+    case 'streak_rate': {
+      const event = typeof source.event === 'string' ? source.event : 'noop';
+      const count = normalizeNumber(source.count, 1);
+      const max_interval_s = normalizeNumber(source.max_interval_s, 1);
+      return { type: 'streak_rate', event, count, max_interval_s };
+    }
+    case 'sequence': {
+      const events = Array.isArray(source.events)
+        ? source.events.filter((ev): ev is string => typeof ev === 'string')
+        : [];
+      const window_s = normalizeNumber(source.window_s, 0);
+      return { type: 'sequence', events, window_s: window_s > 0 ? window_s : undefined };
+    }
+    case 'uptime': {
+      const target_s = normalizeNumber(source.target_s, 0);
+      return { type: 'uptime', target_s };
+    }
+    default:
+      return { type: 'counter', event: 'noop', target: 1 };
+  }
+};
+
+const normalizeTask = (task: unknown): DailyTaskDefinition | null => {
+  if (!task || typeof task !== 'object') return null;
+  const source = task as Record<string, unknown>;
+  const id = typeof source.id === 'string' ? source.id : null;
+  const title_fi = typeof source.title_fi === 'string' ? source.title_fi : '';
+  const desc_fi = typeof source.desc_fi === 'string' ? source.desc_fi : '';
+  if (!id || !title_fi) return null;
+  const category = typeof source.category === 'string' ? source.category : 'general';
+  const reward = typeof source.reward === 'string' ? source.reward : '';
+  const weight = normalizeNumber(source.weight, 1);
+  const min_tier = normalizeNumber(source.min_tier, 0);
+  const max_per_day = Math.max(1, normalizeNumber(source.max_per_day, 1));
+  const requires_feature = typeof source.requires_feature === 'string' ? source.requires_feature : undefined;
+  const condition = normalizeCondition(source.condition);
+  return {
+    id,
+    title_fi,
+    desc_fi,
+    category,
+    condition,
+    reward,
+    weight: Math.max(0, weight),
+    min_tier: Math.max(0, Math.floor(min_tier)),
+    max_per_day,
+    requires_feature,
+  };
+};
+
+const normalizeReward = (reward: unknown): DailyTaskRewardTemplate | null => {
+  if (!reward || typeof reward !== 'object') return null;
+  const source = reward as Record<string, unknown>;
+  const type = source.type === 'temp_gain_mult' ? 'temp_gain_mult' : null;
+  if (!type) return null;
+  const value = normalizeNumber(source.value, 0);
+  const duration_s = Math.max(0, normalizeNumber(source.duration_s, 0));
+  const cooldown_s = Math.max(0, normalizeNumber(source.cooldown_s, 0));
+  return { type, value, duration_s, cooldown_s };
+};
+
+const normalizeConfig = (raw: unknown): DailyTasksConfig => {
+  const source = raw as Record<string, unknown> | undefined;
+  const version = normalizeNumber(source?.version, 1);
+  const reset_timezone = typeof source?.reset_timezone === 'string' ? source?.reset_timezone : 'UTC';
+  const rotationRaw = source?.daily_rotation as Record<string, unknown> | undefined;
+  const selectionRaw = rotationRaw?.selection as Record<string, unknown> | undefined;
+  const rotation: DailyTasksSelectionConfig = {
+    tasks_per_day: Math.max(1, normalizeNumber(rotationRaw?.tasks_per_day, 3)),
+    allow_duplicates_same_day: rotationRaw?.allow_duplicates_same_day === true,
+    reroll_cost_population: Math.max(0, normalizeNumber(rotationRaw?.reroll_cost_population, 0)),
+    reroll_limit_per_day: Math.max(0, normalizeNumber(rotationRaw?.reroll_limit_per_day, 0)),
+    selection: {
+      use_weights: selectionRaw?.use_weights !== false,
+      min_tier: Math.max(0, normalizeNumber(selectionRaw?.min_tier, 0)),
+      max_active_per_category: Math.max(1, normalizeNumber(selectionRaw?.max_active_per_category, 1)),
+    },
+  };
+  const rewardsRaw = source?.reward_templates as Record<string, unknown> | undefined;
+  const reward_templates: Record<string, DailyTaskRewardTemplate> = {};
+  if (rewardsRaw) {
+    for (const [key, value] of Object.entries(rewardsRaw)) {
+      const reward = normalizeReward(value);
+      if (reward) reward_templates[key] = reward;
+    }
+  }
+  const tasksRaw = Array.isArray(source?.tasks) ? (source?.tasks as unknown[]) : [];
+  const tasks: DailyTaskDefinition[] = [];
+  for (const entry of tasksRaw) {
+    const task = normalizeTask(entry);
+    if (task) tasks.push(task);
+  }
+  const uiTexts = source?.ui_texts_fi as Record<string, string> | undefined;
+  const ui_texts_fi: Record<string, string> = {};
+  if (uiTexts) {
+    for (const [key, value] of Object.entries(uiTexts)) {
+      if (typeof value === 'string') ui_texts_fi[key] = value;
+    }
+  }
+  const telemetryConfig = source?.telemetry as Record<string, unknown> | undefined;
+  const telemetryNormalized: DailyTasksTelemetryConfig | undefined = telemetryConfig
+    ? {
+        log_task_rolls: telemetryConfig.log_task_rolls === true,
+        log_completions: telemetryConfig.log_completions === true,
+        log_claims: telemetryConfig.log_claims === true,
+        log_buff_start_end: telemetryConfig.log_buff_start_end === true,
+      }
+    : undefined;
+  return {
+    version,
+    reset_timezone,
+    daily_rotation: rotation,
+    reward_templates,
+    tasks,
+    ui_texts_fi,
+    telemetry: telemetryNormalized,
+  };
+};
+
+export const dailyTasksConfig: DailyTasksConfig = normalizeConfig(dailyTasksData);
+
+const tasksById = new Map<string, DailyTaskDefinition>();
+for (const task of dailyTasksConfig.tasks) {
+  tasksById.set(task.id, task);
+}
+
+const hasFeature = (context: DailyTaskPlayerContext, feature: string) => {
+  if (feature === 'prestige') {
+    return context.prestigeUnlocked;
+  }
+  return true;
+};
+
+const hashString = (value: string) => {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+    hash >>>= 0;
+  }
+  return hash >>> 0;
+};
+
+const createSeededRng = (seedValue: string) => {
+  let seed = hashString(seedValue) || 1;
+  return () => {
+    seed = (seed + 0x6d2b79f5) >>> 0;
+    let t = seed;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+const toDateParts = (timestamp: number, timeZone: string) => {
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+  const parts = formatter.formatToParts(new Date(timestamp));
+  const get = (type: string) => parts.find((part) => part.type === type)?.value ?? '0';
+  return {
+    year: Number(get('year')),
+    month: Number(get('month')),
+    day: Number(get('day')),
+    hour: Number(get('hour')),
+    minute: Number(get('minute')),
+    second: Number(get('second')),
+  };
+};
+
+const zonedTimeToUtc = (
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  second: number,
+  timeZone: string,
+) => {
+  const utcDate = new Date(Date.UTC(year, month - 1, day, hour, minute, second));
+  const localeString = utcDate.toLocaleString('en-US', { timeZone });
+  const localDate = new Date(localeString);
+  const diff = utcDate.getTime() - localDate.getTime();
+  return utcDate.getTime() + diff;
+};
+
+const getDateKey = (timestamp: number, timeZone: string) => {
+  const parts = toDateParts(timestamp, timeZone);
+  const month = String(parts.month).padStart(2, '0');
+  const day = String(parts.day).padStart(2, '0');
+  return `${parts.year}-${month}-${day}`;
+};
+
+const getNextResetAt = (timestamp: number, timeZone: string) => {
+  const parts = toDateParts(timestamp, timeZone);
+  const startUtc = zonedTimeToUtc(parts.year, parts.month, parts.day, 0, 0, 0, timeZone);
+  const nextUtc = new Date(startUtc);
+  nextUtc.setUTCDate(nextUtc.getUTCDate() + 1);
+  const nextParts = toDateParts(nextUtc.getTime(), timeZone);
+  return zonedTimeToUtc(nextParts.year, nextParts.month, nextParts.day, 0, 0, 0, timeZone);
+};
+
+export const createInitialDailyTasksState = (): DailyTasksState => ({
+  rolledDate: null,
+  taskOrder: [],
+  tasks: {},
+  activeBuffs: [],
+  metrics: {
+    baselines: {},
+    current: {},
+    uptimeSeconds: 0,
+    lastUptimeUpdate: null,
+  },
+  nextResetAt: null,
+  rerollsUsed: 0,
+});
+
+const cloneConditionState = (
+  state?: DailyTaskConditionState,
+): DailyTaskConditionState | undefined => {
+  if (!state) return undefined;
+  switch (state.type) {
+    case 'counter':
+      return {
+        type: 'counter',
+        count: state.count,
+        byKey: state.byKey ? { ...state.byKey } : undefined,
+      };
+    case 'streak':
+      return { type: 'streak', events: [...state.events] };
+    case 'streak_rate':
+      return { type: 'streak_rate', count: state.count, lastTimestamp: state.lastTimestamp };
+    case 'sequence':
+      return { type: 'sequence', index: state.index, lastEventTime: state.lastEventTime };
+    case 'uptime':
+      return { type: 'uptime' };
+    default:
+      return undefined;
+  }
+};
+
+const cloneTasks = (tasks: Record<string, DailyTaskInstanceState>) => {
+  const next: Record<string, DailyTaskInstanceState> = {};
+  for (const [id, task] of Object.entries(tasks)) {
+    next[id] = { ...task, conditionState: cloneConditionState(task.conditionState) };
+  }
+  return next;
+};
+
+const pruneExpiredBuffs = (state: DailyTasksState, now: number): DailyTasksState => {
+  if (!state.activeBuffs.length) return state;
+  const active: DailyTaskBuff[] = [];
+  let changed = false;
+  for (const buff of state.activeBuffs) {
+    if (buff.endsAt > now) {
+      active.push(buff);
+    } else {
+      changed = true;
+      dispatchToast({
+        type: 'buff_expired',
+        taskId: buff.taskId,
+        taskTitle: tasksById.get(buff.taskId)?.title_fi ?? buff.taskId,
+      });
+      if (dailyTasksConfig.telemetry?.log_buff_start_end) {
+        telemetry.emit('daily_task_buff_end', {
+          taskId: buff.taskId,
+          rewardId: buff.rewardId,
+          endedAt: now,
+        });
+      }
+    }
+  }
+  if (!changed) return state;
+  return { ...state, activeBuffs: active };
+};
+
+const createConditionState = (
+  definition: DailyTaskDefinition,
+): DailyTaskConditionState | undefined => {
+  const { condition } = definition;
+  switch (condition.type) {
+    case 'counter':
+      return { type: 'counter', count: 0 };
+    case 'streak':
+      return { type: 'streak', events: [] };
+    case 'streak_rate':
+      return { type: 'streak_rate', count: 0, lastTimestamp: null };
+    case 'sequence':
+      return { type: 'sequence', index: 0, lastEventTime: null };
+    case 'uptime':
+      return { type: 'uptime' };
+    default:
+      return undefined;
+  }
+};
+
+const buildInitialTasks = (
+  dateKey: string,
+  selection: DailyTaskDefinition[],
+): RollResult => {
+  const tasks: Record<string, DailyTaskInstanceState> = {};
+  const taskOrder = selection.map((task) => task.id);
+  for (const task of selection) {
+    tasks[task.id] = {
+      id: task.id,
+      rolledAt: dateKey,
+      progress: 0,
+      completedAt: null,
+      claimedAt: null,
+      conditionState: createConditionState(task),
+    };
+  }
+  return { taskOrder, tasks };
+};
+
+const buildInitialMetrics = (
+  context: DailyTaskPlayerContext,
+  now: number,
+): DailyTaskMetricsState => ({
+  baselines: {
+    temperature: context.population,
+    population_earned_today: context.population,
+    prestige_multiplier: context.prestigeMult,
+  },
+  current: {
+    temperature: context.population,
+    population_earned_today: context.population,
+    prestige_multiplier: context.prestigeMult,
+  },
+  uptimeSeconds: 0,
+  lastUptimeUpdate: now,
+});
+
+const resolveMetricValue = (
+  metric: string,
+  context: DailyTaskPlayerContext,
+  metrics: DailyTaskMetricsState,
+): number => {
+  switch (metric) {
+    case 'temperature':
+      return context.population;
+    case 'prestige_multiplier':
+      return context.prestigeMult;
+    case 'population_earned_today':
+      return context.population;
+    default:
+      return metrics.current[metric] ?? 0;
+  }
+};
+
+const resolveMetricDelta = (
+  metric: string,
+  context: DailyTaskPlayerContext,
+  metrics: DailyTaskMetricsState,
+): number => {
+  const current = resolveMetricValue(metric, context, metrics);
+  const baseline = metrics.baselines[metric];
+  if (!Number.isFinite(baseline)) {
+    metrics.baselines[metric] = current;
+    return 0;
+  }
+  return current - baseline;
+};
+
+const getConditionTarget = (condition: DailyTaskCondition): number => {
+  switch (condition.type) {
+    case 'counter':
+      return condition.target;
+    case 'threshold':
+      return condition.target;
+    case 'delta_threshold':
+      return condition.target;
+    case 'streak':
+      return condition.window_s;
+    case 'streak_rate':
+      return condition.count;
+    case 'sequence':
+      return condition.events.length;
+    case 'uptime':
+      return condition.target_s;
+    default:
+      return 0;
+  }
+};
+
+const applyProgressUpdate = (
+  task: DailyTaskInstanceState,
+  definition: DailyTaskDefinition,
+  rawProgress: number,
+  now: number,
+): DailyTaskInstanceState => {
+  const target = getConditionTarget(definition.condition);
+  const safeProgress = Number.isFinite(rawProgress) ? rawProgress : 0;
+  const clamped = target > 0 ? Math.min(safeProgress, target) : safeProgress;
+  let changed = task.progress !== clamped;
+  let completedAt = task.completedAt;
+  if (completedAt === null && target > 0 && safeProgress >= target) {
+    completedAt = now;
+    changed = true;
+    dispatchToast({
+      type: 'complete',
+      taskId: task.id,
+      taskTitle: definition.title_fi,
+    });
+    if (dailyTasksConfig.telemetry?.log_completions) {
+      telemetry.emit('daily_task_complete', {
+        taskId: task.id,
+        completedAt: now,
+        date: task.rolledAt,
+      });
+    }
+  }
+  if (!changed) return task;
+  return { ...task, progress: clamped, completedAt };
+};
+
+export const updateDailyTaskMetrics = (
+  state: DailyTasksState,
+  context: DailyTaskPlayerContext,
+  now: number,
+): DailyTasksState => {
+  const metrics: DailyTaskMetricsState = {
+    baselines: { ...state.metrics.baselines },
+    current: { ...state.metrics.current },
+    uptimeSeconds: state.metrics.uptimeSeconds,
+    lastUptimeUpdate: state.metrics.lastUptimeUpdate,
+  };
+  metrics.current.temperature = context.population;
+  metrics.current.prestige_multiplier = context.prestigeMult;
+  metrics.current.population_earned_today = context.population;
+  if (!state.taskOrder.length) {
+    return { ...state, metrics };
+  }
+  let changed = false;
+  const tasks = cloneTasks(state.tasks);
+  for (const taskId of state.taskOrder) {
+    const definition = tasksById.get(taskId);
+    if (!definition) continue;
+    const task = tasks[taskId];
+    if (!task) continue;
+    let progress = task.progress;
+    switch (definition.condition.type) {
+      case 'threshold': {
+        progress = resolveMetricValue(definition.condition.metric, context, metrics);
+        break;
+      }
+      case 'delta_threshold': {
+        progress = resolveMetricDelta(definition.condition.metric, context, metrics);
+        break;
+      }
+      case 'uptime': {
+        progress = metrics.uptimeSeconds;
+        break;
+      }
+      default:
+        continue;
+    }
+    const updated = applyProgressUpdate(task, definition, progress, now);
+    if (updated !== task) {
+      tasks[taskId] = updated;
+      changed = true;
+    }
+  }
+  if (!changed) return { ...state, metrics };
+  return { ...state, tasks, metrics };
+};
+
+const handleCounterTask = (
+  task: DailyTaskInstanceState,
+  definition: DailyTaskDefinition,
+  event: DailyTaskEvent,
+  now: number,
+): DailyTaskInstanceState => {
+  if (definition.condition.type !== 'counter') return task;
+  if (definition.condition.event !== event.type) return task;
+  const conditionState: DailyTaskCounterState =
+    task.conditionState?.type === 'counter'
+      ? { ...task.conditionState, byKey: task.conditionState.byKey ? { ...task.conditionState.byKey } : undefined }
+      : { type: 'counter', count: 0 };
+  let progress = conditionState.count;
+  if (event.type === 'building_bought_same_type') {
+    const key = typeof event.buildingId === 'string' ? event.buildingId : 'default';
+    const current = conditionState.byKey?.[key] ?? 0;
+    const next = current + 1;
+    conditionState.byKey = { ...(conditionState.byKey ?? {}), [key]: next };
+    conditionState.count = Math.max(conditionState.count, next);
+    progress = conditionState.count;
+  } else {
+    conditionState.count += 1;
+    progress = conditionState.count;
+  }
+  const baseTask: DailyTaskInstanceState = { ...task, conditionState };
+  return applyProgressUpdate(baseTask, definition, progress, now);
+};
+
+const handleStreakTask = (
+  task: DailyTaskInstanceState,
+  definition: DailyTaskDefinition,
+  event: DailyTaskEvent,
+  now: number,
+): DailyTaskInstanceState => {
+  if (definition.condition.type !== 'streak') return task;
+  if (definition.condition.event !== event.type) return task;
+  const conditionState: DailyTaskStreakState =
+    task.conditionState?.type === 'streak'
+      ? { type: 'streak', events: [...task.conditionState.events] }
+      : { type: 'streak', events: [] };
+  const events = conditionState.events;
+  events.push(now);
+  const windowMs = Math.max(0, definition.condition.window_s * 1000);
+  const maxGapMs = Math.max(0, definition.condition.max_gap_s * 1000);
+  while (events.length > 0 && now - events[0] > windowMs) {
+    events.shift();
+  }
+  if (events.length > 1 && maxGapMs > 0) {
+    for (let i = events.length - 1; i > 0; i -= 1) {
+      if (events[i] - events[i - 1] > maxGapMs) {
+        events.splice(0, i);
+        break;
+      }
+    }
+  }
+  let progress = 0;
+  if (events.length >= 2) {
+    progress = (events[events.length - 1] - events[0]) / 1000;
+  }
+  progress = Math.max(0, progress);
+  const baseTask: DailyTaskInstanceState = { ...task, conditionState };
+  return applyProgressUpdate(baseTask, definition, progress, now);
+};
+
+const handleStreakRateTask = (
+  task: DailyTaskInstanceState,
+  definition: DailyTaskDefinition,
+  event: DailyTaskEvent,
+  now: number,
+): DailyTaskInstanceState => {
+  if (definition.condition.type !== 'streak_rate') return task;
+  if (definition.condition.event !== event.type) return task;
+  const conditionState: DailyTaskStreakRateState =
+    task.conditionState?.type === 'streak_rate'
+      ? { ...task.conditionState }
+      : { type: 'streak_rate', count: 0, lastTimestamp: null };
+  const maxIntervalMs = Math.max(0, definition.condition.max_interval_s * 1000);
+  if (
+    conditionState.lastTimestamp !== null &&
+    now - conditionState.lastTimestamp <= maxIntervalMs
+  ) {
+    conditionState.count += 1;
+  } else {
+    conditionState.count = 1;
+  }
+  conditionState.lastTimestamp = now;
+  const baseTask: DailyTaskInstanceState = { ...task, conditionState };
+  return applyProgressUpdate(baseTask, definition, conditionState.count, now);
+};
+
+const handleSequenceTask = (
+  task: DailyTaskInstanceState,
+  definition: DailyTaskDefinition,
+  event: DailyTaskEvent,
+  now: number,
+): DailyTaskInstanceState => {
+  if (definition.condition.type !== 'sequence') return task;
+  const steps = definition.condition.events;
+  if (!steps.length) return task;
+  const conditionState: DailyTaskSequenceState =
+    task.conditionState?.type === 'sequence'
+      ? { ...task.conditionState }
+      : { type: 'sequence', index: 0, lastEventTime: null };
+  const windowMs = (definition.condition.window_s ?? 0) * 1000;
+  if (
+    windowMs > 0 &&
+    conditionState.lastEventTime !== null &&
+    now - conditionState.lastEventTime > windowMs
+  ) {
+    conditionState.index = 0;
+    conditionState.lastEventTime = null;
+  }
+  const eventType = event.type;
+  let index = conditionState.index;
+  let lastEventTime = conditionState.lastEventTime;
+  if (eventType === steps[index]) {
+    if (index === 0) lastEventTime = now;
+    index += 1;
+    if (index >= steps.length) {
+      index = steps.length;
+    }
+  } else if (eventType === steps[0]) {
+    index = 1;
+    lastEventTime = now;
+  }
+  conditionState.index = index;
+  conditionState.lastEventTime = lastEventTime;
+  const progress = Math.min(index, steps.length);
+  const baseTask: DailyTaskInstanceState = { ...task, conditionState };
+  return applyProgressUpdate(baseTask, definition, progress, now);
+};
+
+export const handleDailyTaskEvent = (
+  state: DailyTasksState,
+  event: DailyTaskEvent,
+  context: DailyTaskPlayerContext,
+  now: number,
+): DailyTasksState => {
+  if (!state.taskOrder.length) return state;
+  const tasks = cloneTasks(state.tasks);
+  let changed = false;
+  for (const taskId of state.taskOrder) {
+    const definition = tasksById.get(taskId);
+    if (!definition) continue;
+    const task = tasks[taskId];
+    if (!task) continue;
+    let updated = task;
+    switch (definition.condition.type) {
+      case 'counter':
+        updated = handleCounterTask(task, definition, event, now);
+        break;
+      case 'streak':
+        updated = handleStreakTask(task, definition, event, now);
+        break;
+      case 'streak_rate':
+        updated = handleStreakRateTask(task, definition, event, now);
+        break;
+      case 'sequence':
+        updated = handleSequenceTask(task, definition, event, now);
+        break;
+      default:
+        break;
+    }
+    if (updated !== task) {
+      tasks[taskId] = updated;
+      changed = true;
+    }
+  }
+  if (!changed) return state;
+  const nextState = { ...state, tasks };
+  return updateDailyTaskMetrics(nextState, context, now);
+};
+
+export const applyUptimeProgress = (
+  state: DailyTasksState,
+  context: DailyTaskPlayerContext,
+  deltaSeconds: number,
+  now: number,
+  options?: { offline?: boolean },
+): DailyTasksState => {
+  if (options?.offline) {
+    return updateDailyTaskMetrics(state, context, now);
+  }
+  const metrics: DailyTaskMetricsState = {
+    ...state.metrics,
+    uptimeSeconds: Math.max(0, state.metrics.uptimeSeconds + deltaSeconds),
+    lastUptimeUpdate: now,
+  };
+  const nextState = { ...state, metrics };
+  return updateDailyTaskMetrics(nextState, context, now);
+};
+
+export const getTemperatureGainMultiplier = (state: DailyTasksState): number => {
+  if (!state.activeBuffs.length) return 1;
+  return state.activeBuffs.reduce((multiplier, buff) => multiplier * (1 + buff.value), 1);
+};
+
+export const refreshBuffs = (
+  state: DailyTasksState,
+  now: number,
+): DailyTasksState => pruneExpiredBuffs(state, now);
+
+export const getEffectiveTemperatureMultiplier = (
+  state: DailyTasksState,
+  now: number,
+): { state: DailyTasksState; multiplier: number } => {
+  const cleaned = refreshBuffs(state, now);
+  return { state: cleaned, multiplier: getTemperatureGainMultiplier(cleaned) };
+};
+
+export const claimDailyTaskReward = (
+  state: DailyTasksState,
+  taskId: string,
+  now: number,
+): { state: DailyTasksState; buff: DailyTaskBuff | null } => {
+  const task = state.tasks[taskId];
+  const definition = tasksById.get(taskId);
+  if (!task || !definition) return { state, buff: null };
+  if (!task.completedAt || task.claimedAt) return { state, buff: null };
+  const reward = dailyTasksConfig.reward_templates[definition.reward];
+  const nextTask: DailyTaskInstanceState = { ...task, claimedAt: now };
+  const tasks = { ...state.tasks, [taskId]: nextTask };
+  let activeBuffs = state.activeBuffs.filter((buff) => buff.taskId !== taskId || buff.endsAt > now);
+  let buff: DailyTaskBuff | null = null;
+  if (reward && reward.type === 'temp_gain_mult') {
+    const endsAt = now + reward.duration_s * 1000;
+    buff = {
+      taskId,
+      rewardId: definition.reward,
+      type: 'temp_gain_mult',
+      value: reward.value,
+      endsAt,
+    };
+    activeBuffs = [...activeBuffs, buff];
+    dispatchToast({
+      type: 'claim',
+      taskId,
+      taskTitle: definition.title_fi,
+      rewardValue: reward.value,
+      rewardDuration: reward.duration_s,
+    });
+    if (dailyTasksConfig.telemetry?.log_buff_start_end) {
+      telemetry.emit('daily_task_buff_start', {
+        taskId,
+        rewardId: definition.reward,
+        value: reward.value,
+        duration_s: reward.duration_s,
+        startedAt: now,
+      });
+    }
+  }
+  if (dailyTasksConfig.telemetry?.log_claims) {
+    telemetry.emit('daily_task_claim', {
+      taskId,
+      rewardId: definition.reward,
+      claimedAt: now,
+    });
+  }
+  const nextState = { ...state, tasks, activeBuffs };
+  return { state: nextState, buff };
+};
+
+export const syncDailyTasksState = (
+  state: DailyTasksState,
+  context: DailyTaskPlayerContext,
+  now: number,
+): DailyTasksState => {
+  const ensured = ensureDailyTasksForToday(state, context, now);
+  return updateDailyTaskMetrics(ensured, context, now);
+};
+
+export const getDailyTaskDefinition = (id: string) => tasksById.get(id);
+
+export const getRewardTemplate = (id: string) => dailyTasksConfig.reward_templates[id];
+
+export const getTaskTarget = (definition: DailyTaskDefinition) =>
+  Math.max(0, getConditionTarget(definition.condition));
+
+const pickTasks = (
+  context: DailyTaskPlayerContext,
+  dateKey: string,
+  rng: () => number,
+): DailyTaskDefinition[] => {
+  void dateKey;
+  const { daily_rotation } = dailyTasksConfig;
+  const results: DailyTaskDefinition[] = [];
+  const usedCategories = new Map<string, number>();
+  const allowDuplicates = daily_rotation.allow_duplicates_same_day;
+  const maxPerCategory = Math.max(1, daily_rotation.selection.max_active_per_category);
+  const selectionMinTier = Math.max(0, daily_rotation.selection.min_tier);
+  const tierIndex = Math.max(0, Math.floor(context.tierLevel) - 1);
+  const available = dailyTasksConfig.tasks.filter((task) => {
+    if (task.weight <= 0) return false;
+    if (tierIndex < task.min_tier) return false;
+    if (task.min_tier < selectionMinTier) return false;
+    if (task.requires_feature && !hasFeature(context, task.requires_feature)) return false;
+    return true;
+  });
+  const pool: DailyTaskDefinition[] = [...available];
+  while (results.length < daily_rotation.tasks_per_day && pool.length > 0) {
+    const eligible = pool.filter((task) => {
+      const used = usedCategories.get(task.category) ?? 0;
+      return used < maxPerCategory;
+    });
+    if (eligible.length === 0) break;
+    const totalWeight = eligible.reduce((sum, task) => {
+      if (!daily_rotation.selection.use_weights) return sum + 1;
+      return sum + task.weight;
+    }, 0);
+    if (totalWeight <= 0) break;
+    let roll = rng() * totalWeight;
+    let chosen: DailyTaskDefinition | null = null;
+    for (const task of eligible) {
+      const weight = daily_rotation.selection.use_weights ? task.weight : 1;
+      if (roll < weight) {
+        chosen = task;
+        break;
+      }
+      roll -= weight;
+    }
+    if (!chosen) {
+      chosen = eligible[eligible.length - 1];
+    }
+    results.push(chosen);
+    usedCategories.set(chosen.category, (usedCategories.get(chosen.category) ?? 0) + 1);
+    if (!allowDuplicates) {
+      const index = pool.findIndex((task) => task.id === chosen?.id);
+      if (index >= 0) pool.splice(index, 1);
+    }
+  }
+  return results;
+};
+
+export const ensureDailyTasksForToday = (
+  state: DailyTasksState,
+  context: DailyTaskPlayerContext,
+  now: number,
+  rngFactory?: (seed: string) => () => number,
+): DailyTasksState => {
+  const cleaned = pruneExpiredBuffs(state, now);
+  const dateKey = getDateKey(now, dailyTasksConfig.reset_timezone);
+  const nextResetAt = getNextResetAt(now, dailyTasksConfig.reset_timezone);
+  if (cleaned.rolledDate === dateKey) {
+    if (cleaned.nextResetAt !== nextResetAt) {
+      return { ...cleaned, nextResetAt };
+    }
+    return cleaned;
+  }
+  const seed = `${dateKey}:${context.tierLevel}:${Math.floor(context.prestigeMult * 1000)}`;
+  const rng = rngFactory ? rngFactory(seed) : createSeededRng(seed);
+  const selection = pickTasks(context, dateKey, rng);
+  const { taskOrder, tasks } = buildInitialTasks(dateKey, selection);
+  const metrics = buildInitialMetrics(context, now);
+  const nextState: DailyTasksState = {
+    ...cleaned,
+    rolledDate: dateKey,
+    taskOrder,
+    tasks,
+    metrics,
+    nextResetAt,
+    rerollsUsed: 0,
+  };
+  if (dailyTasksConfig.telemetry?.log_task_rolls) {
+    telemetry.emit('daily_task_roll', {
+      date: dateKey,
+      taskIds: taskOrder,
+      rolledAt: now,
+    });
+  }
+  return nextState;
+};

--- a/src/ui/dailyTasks.css
+++ b/src/ui/dailyTasks.css
@@ -1,0 +1,153 @@
+.daily-tasks {
+  background: color-mix(in srgb, var(--surface) 85%, transparent);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  margin: 1rem auto;
+  width: min(360px, 90vw);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.25);
+}
+
+.daily-tasks__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.daily-tasks__title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.daily-tasks__reset {
+  font-size: 0.875rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.daily-tasks__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.daily-tasks__card {
+  background: color-mix(in srgb, var(--surface-elevated) 80%, transparent);
+  border-radius: 0.75rem;
+  padding: 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.daily-tasks__card-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.daily-tasks__card-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.daily-tasks__card-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.daily-tasks__card-desc {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.daily-tasks__status {
+  align-self: flex-start;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.daily-tasks__status--completed {
+  background: rgba(46, 204, 113, 0.15);
+  color: #6ff2a5;
+}
+
+.daily-tasks__status--active {
+  background: rgba(52, 152, 219, 0.2);
+  color: #8cc9ff;
+}
+
+.daily-tasks__status--expired {
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.daily-tasks__progress {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.daily-tasks__progress-bar {
+  height: 0.4rem;
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.daily-tasks__progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--brand-primary), #9d7dff);
+  border-radius: inherit;
+}
+
+.daily-tasks__progress-label {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.daily-tasks__empty {
+  text-align: center;
+  font-size: 0.85rem;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.daily-tasks__toast {
+  position: relative;
+  align-self: center;
+  background: rgba(0, 0, 0, 0.8);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  font-size: 0.85rem;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+  animation: daily-tasks-toast-in 150ms ease-out;
+}
+
+@keyframes daily-tasks-toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 480px) {
+  .daily-tasks {
+    width: 95vw;
+  }
+}

--- a/src/ui/dailyTasksUI.tsx
+++ b/src/ui/dailyTasksUI.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useGameStore } from '../app/store';
+import {
+  dailyTasksConfig,
+  dailyTaskEventTarget,
+  DAILY_TASK_TOAST_EVENT,
+  type DailyTaskToastDetail,
+  getDailyTaskDefinition,
+  getTaskTarget,
+} from '../systems/dailyTasks';
+import { formatNumber } from '../utils/format';
+import './dailyTasks.css';
+
+const formatTime = (totalSeconds: number) => {
+  const safeSeconds = Math.max(0, Math.floor(totalSeconds));
+  const hours = Math.floor(safeSeconds / 3600);
+  const minutes = Math.floor((safeSeconds % 3600) / 60);
+  const seconds = safeSeconds % 60;
+  const segments = [minutes.toString().padStart(2, '0'), seconds.toString().padStart(2, '0')];
+  if (hours > 0) {
+    segments.unshift(hours.toString().padStart(2, '0'));
+  }
+  return segments.join(':');
+};
+
+interface ToastState {
+  id: number;
+  message: string;
+}
+
+export function DailyTasksPanel() {
+  const dailyTasks = useGameStore((state) => state.dailyTasks);
+  const claimReward = useGameStore((state) => state.claimDailyTaskReward);
+  const uiTexts = dailyTasksConfig.ui_texts_fi;
+  const [now, setNow] = useState(() => Date.now());
+  const [toast, setToast] = useState<ToastState | null>(null);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(timer);
+  }, []);
+
+  useEffect(() => {
+    let toastTimer: number | undefined;
+    const handler = (event: Event) => {
+      const custom = event as CustomEvent<DailyTaskToastDetail>;
+      const detail = custom.detail;
+      if (!detail) return;
+      let message = detail.taskTitle;
+      if (detail.type === 'complete') {
+        message = `${detail.taskTitle} · ${uiTexts.completed}`;
+      } else if (detail.type === 'claim') {
+        const pct = detail.rewardValue !== undefined ? Math.round(detail.rewardValue * 100) : null;
+        const duration =
+          detail.rewardDuration !== undefined ? formatTime(detail.rewardDuration) : undefined;
+        const suffix = [uiTexts.reward_active, pct !== null ? `+${pct}%` : null, duration]
+          .filter(Boolean)
+          .join(' · ');
+        message = `${detail.taskTitle} · ${suffix}`;
+      } else if (detail.type === 'buff_expired') {
+        message = `${detail.taskTitle} · ${uiTexts.reward_expired}`;
+      }
+      if (toastTimer !== undefined) window.clearTimeout(toastTimer);
+      setToast({ id: Date.now(), message });
+      toastTimer = window.setTimeout(() => setToast(null), 4000);
+    };
+    dailyTaskEventTarget.addEventListener(DAILY_TASK_TOAST_EVENT, handler);
+    return () => {
+      if (toastTimer !== undefined) window.clearTimeout(toastTimer);
+      dailyTaskEventTarget.removeEventListener(DAILY_TASK_TOAST_EVENT, handler);
+    };
+  }, [uiTexts.completed, uiTexts.reward_active, uiTexts.reward_expired]);
+
+  const taskViews = useMemo(() => {
+    return dailyTasks.taskOrder
+      .map((taskId) => {
+        const definition = getDailyTaskDefinition(taskId);
+        const state = dailyTasks.tasks[taskId];
+        if (!definition || !state) return null;
+        const target = getTaskTarget(definition);
+        const progress = state.progress;
+        const progressRatio = target > 0 ? Math.min(1, progress / target) : state.completedAt ? 1 : 0;
+        const buff = dailyTasks.activeBuffs.find((entry) => entry.taskId === taskId);
+        const buffMs = buff ? buff.endsAt - now : 0;
+        const claimable = state.completedAt !== null && state.claimedAt === null;
+        const claimed = state.claimedAt !== null;
+        let statusLabel: string | null = null;
+        let statusType: 'default' | 'completed' | 'active' | 'expired' = 'default';
+        if (claimable) {
+          statusLabel = uiTexts.completed;
+          statusType = 'completed';
+        } else if (claimed && buffMs > 0) {
+          statusLabel = `${uiTexts.reward_active} · ${formatTime(buffMs / 1000)}`;
+          statusType = 'active';
+        } else if (claimed) {
+          statusLabel = uiTexts.reward_expired;
+          statusType = 'expired';
+        }
+        const buttonLabel = claimable
+          ? uiTexts.claim_reward
+          : claimed && buffMs > 0
+            ? uiTexts.reward_active
+            : claimed
+              ? uiTexts.reward_expired
+              : uiTexts.progress;
+        return {
+          id: taskId,
+          title: definition.title_fi,
+          description: definition.desc_fi,
+          progress,
+          target,
+          progressRatio,
+          statusLabel,
+          statusType,
+          claimable,
+          claimed,
+          buttonLabel,
+        };
+      })
+      .filter((entry): entry is Exclude<typeof entry, null> => entry !== null);
+  }, [dailyTasks, now, uiTexts]);
+
+  const secondsToReset = dailyTasks.nextResetAt
+    ? Math.max(0, Math.floor((dailyTasks.nextResetAt - now) / 1000))
+    : 0;
+
+  return (
+    <section className="daily-tasks" aria-labelledby="daily-tasks-title">
+      <header className="daily-tasks__header">
+        <h2 id="daily-tasks-title" className="daily-tasks__title">
+          {uiTexts.daily_tasks_title}
+        </h2>
+        <span className="daily-tasks__reset" aria-live="polite">
+          {uiTexts.resets_in}: {formatTime(secondsToReset)}
+        </span>
+      </header>
+      <div className="daily-tasks__list">
+        {taskViews.map((task) => {
+          const formattedProgress = formatNumber(task.progress, { maximumFractionDigits: 0 });
+          const formattedTarget = formatNumber(task.target, { maximumFractionDigits: 0 });
+          const buttonClass = task.claimable
+            ? 'btn btn--primary'
+            : task.claimed
+              ? 'btn btn--success'
+              : 'btn btn--disabled';
+          return (
+            <article className="daily-tasks__card" key={task.id}>
+              <header className="daily-tasks__card-header">
+                <div className="daily-tasks__card-text">
+                  <h3 className="daily-tasks__card-title">{task.title}</h3>
+                  <p className="daily-tasks__card-desc">{task.description}</p>
+                </div>
+                {task.statusLabel && (
+                  <span className={`daily-tasks__status daily-tasks__status--${task.statusType}`}>
+                    {task.statusLabel}
+                  </span>
+                )}
+              </header>
+              <div className="daily-tasks__progress">
+                <div
+                  className="daily-tasks__progress-bar"
+                  role="progressbar"
+                  aria-valuemin={0}
+                  aria-valuemax={task.target}
+                  aria-valuenow={task.progress}
+                >
+                  <div
+                    className="daily-tasks__progress-fill"
+                    style={{ width: `${Math.min(100, Math.max(0, task.progressRatio * 100))}%` }}
+                  />
+                </div>
+                <div className="daily-tasks__progress-label">
+                  {uiTexts.progress}: {formattedProgress} {uiTexts.of} {formattedTarget}
+                </div>
+              </div>
+              <button
+                type="button"
+                className={buttonClass}
+                disabled={!task.claimable}
+                onClick={() => claimReward(task.id)}
+              >
+                {task.buttonLabel}
+              </button>
+            </article>
+          );
+        })}
+        {taskViews.length === 0 && (
+          <div className="daily-tasks__empty" role="status">
+            {uiTexts.progress}: 0 {uiTexts.of} 0
+          </div>
+        )}
+      </div>
+      {toast && (
+        <div className="daily-tasks__toast" role="status">
+          {toast.message}
+        </div>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce the daily tasks data set and evaluation engine for tracking progress, awarding buffs, and emitting telemetry
- integrate daily tasks persistence and event hooks into the store and expose a Daily Tasks panel with countdowns, progress, and reward toasts
- add unit tests for task selection, streak tracking, and reward claiming and document the feature in the changelog

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb1047f4b48328921bc6b666bb43cc