### PR TITLE
feat: add daily tasks drawer with claim alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed
 - Hide the Maailma shop until Polta Maailma has been used at least once.
 - Update the page title to display "suomidle" in browser tabs.
+- Move the daily tasks list into a collapsible drawer beneath the settings menu and highlight ready-to-claim tasks.
 
 
 ### Fixed

--- a/src/ui/dailyTasks.css
+++ b/src/ui/dailyTasks.css
@@ -1,13 +1,93 @@
+.daily-tasks-drawer {
+  position: fixed;
+  top: calc(40px + 1rem);
+  left: 0.5rem;
+  z-index: 900;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.daily-tasks-drawer__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: color-mix(in srgb, var(--surface-elevated) 85%, transparent);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  padding: 0.45rem 0.85rem;
+  color: inherit;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+  transition: background 150ms ease, box-shadow 150ms ease, color 150ms ease;
+}
+
+.daily-tasks-drawer__toggle:hover,
+.daily-tasks-drawer__toggle:focus-visible {
+  background: color-mix(in srgb, var(--surface-elevated) 92%, transparent);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.4);
+}
+
+.daily-tasks-drawer__toggle:focus-visible {
+  outline: 2px solid var(--color-text);
+  outline-offset: 3px;
+}
+
+.daily-tasks-drawer__chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface) 70%, transparent);
+  font-size: 1rem;
+  font-weight: 700;
+  transform: rotate(0deg);
+  transition: transform 150ms ease;
+}
+
+.daily-tasks-drawer--open .daily-tasks-drawer__chevron {
+  transform: rotate(90deg);
+}
+
+.daily-tasks-drawer__label {
+  font-size: 1rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.daily-tasks-drawer__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  background: #ff6b6b;
+  color: #fff;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  padding: 0 0.4rem;
+  line-height: 1;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
+}
+
 .daily-tasks {
   background: color-mix(in srgb, var(--surface) 85%, transparent);
   border-radius: 0.75rem;
   padding: 1rem;
-  margin: 1rem auto;
-  width: min(360px, 90vw);
+  width: min(360px, calc(100vw - 1.5rem));
   display: flex;
   flex-direction: column;
   gap: 1rem;
   box-shadow: 0 6px 24px rgba(0, 0, 0, 0.25);
+  max-height: min(540px, calc(100vh - 6.5rem));
+  overflow-y: auto;
 }
 
 .daily-tasks__header {
@@ -126,11 +206,12 @@
 
 .daily-tasks__toast {
   position: relative;
-  align-self: center;
+  align-self: flex-start;
   background: rgba(0, 0, 0, 0.8);
   border-radius: 0.75rem;
   padding: 0.75rem 1rem;
   font-size: 0.85rem;
+  margin-left: 0.25rem;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
   animation: daily-tasks-toast-in 150ms ease-out;
 }
@@ -147,7 +228,12 @@
 }
 
 @media (max-width: 480px) {
+  .daily-tasks-drawer {
+    top: calc(28px + 1rem);
+  }
+
   .daily-tasks {
-    width: 95vw;
+    width: min(320px, calc(100vw - 1rem));
+    max-height: calc(100vh - 7rem);
   }
 }

--- a/src/ui/dailyTasksUI.test.tsx
+++ b/src/ui/dailyTasksUI.test.tsx
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { fireEvent, render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { DailyTasksPanel } from './dailyTasksUI';
+import { useGameStore } from '../app/store';
+import { createInitialDailyTasksState, dailyTasksConfig } from '../systems/dailyTasks';
+
+const resetDailyTasks = () => {
+  useGameStore.setState({ dailyTasks: createInitialDailyTasksState() });
+};
+
+const uiTexts = dailyTasksConfig.ui_texts_fi;
+
+describe('DailyTasksPanel', () => {
+  beforeEach(() => {
+    resetDailyTasks();
+  });
+
+  afterEach(() => {
+    cleanup();
+    resetDailyTasks();
+  });
+
+  it('is collapsed by default and expands when toggled', () => {
+    render(<DailyTasksPanel />);
+    expect(
+      screen.queryByRole('heading', { level: 2, name: uiTexts.daily_tasks_title }),
+    ).not.toBeInTheDocument();
+    const toggle = screen.getByRole('button', { name: new RegExp(uiTexts.daily_tasks_title, 'i') });
+    fireEvent.click(toggle);
+    expect(
+      screen.getByRole('heading', { level: 2, name: uiTexts.daily_tasks_title }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows a ready indicator when tasks can be claimed', () => {
+    const definition = dailyTasksConfig.tasks[0];
+    const now = Date.now();
+    useGameStore.setState({
+      dailyTasks: {
+        ...createInitialDailyTasksState(),
+        rolledDate: '2024-01-01',
+        taskOrder: [definition.id],
+        tasks: {
+          [definition.id]: {
+            id: definition.id,
+            rolledAt: '2024-01-01T00:00:00.000Z',
+            progress: 1,
+            completedAt: now,
+            claimedAt: null,
+          },
+        },
+        nextResetAt: now + 60_000,
+      },
+    });
+
+    render(<DailyTasksPanel />);
+
+    expect(screen.getByLabelText('1 task ready to claim')).toBeInTheDocument();
+    const toggle = screen.getByRole('button', { name: new RegExp(uiTexts.daily_tasks_title, 'i') });
+    fireEvent.click(toggle);
+    expect(screen.getByText(definition.title_fi)).toBeInTheDocument();
+  });
+
+  it('hides the ready indicator when no tasks are claimable', () => {
+    const definition = dailyTasksConfig.tasks[0];
+    const now = Date.now();
+    useGameStore.setState({
+      dailyTasks: {
+        ...createInitialDailyTasksState(),
+        rolledDate: '2024-01-01',
+        taskOrder: [definition.id],
+        tasks: {
+          [definition.id]: {
+            id: definition.id,
+            rolledAt: '2024-01-01T00:00:00.000Z',
+            progress: 0,
+            completedAt: null,
+            claimedAt: null,
+          },
+        },
+        nextResetAt: now + 60_000,
+      },
+    });
+
+    render(<DailyTasksPanel />);
+
+    expect(screen.queryByLabelText(/tasks ready to claim/i)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add a collapsible daily tasks drawer anchored beneath the settings menu
- surface an alert badge when any daily tasks are ready to claim and adjust styling to match the new layout
- cover the drawer toggle and alert indicator with dedicated UI tests

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb2140548c8328ba7aec79ee6d7a8c