### PR TITLE
Scope persisted storage by environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 - Hide the Maailma shop until Polta Maailma has been used at least once.
 - Update the page title to display "suomidle" in browser tabs.
+- Namespace persisted local storage keys by environment to isolate saves across deployments.
 
 
 ### Fixed


### PR DESCRIPTION
## Summary
- derive a normalized storage namespace from `VITE_STORAGE_NAMESPACE`, `BASE_URL`, or the build mode so non-production deployments persist to isolated slots
- document the storage behavior in the store module and update the changelog for visibility
- export the derived key, update existing tests, and add a regression test that rehydrates distinct namespaces without collisions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb25f361208328aed958ae07fd9fa8