### PR TITLE
Format large numbers with scientific notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Update the page title to display "suomidle" in browser tabs.
 - Namespace persisted local storage keys by environment to isolate saves across deployments.
 - Move the daily tasks list into a collapsible drawer beneath the settings menu and highlight ready-to-claim tasks.
+- Display large numeric values in scientific notation once they exceed 1e9 to improve readability in the UI.
 
 
 ### Fixed

--- a/src/i18n/useLocale.test.tsx
+++ b/src/i18n/useLocale.test.tsx
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { renderWithI18n, setTestLanguage } from '../tests/testUtils';
+import { useLocale } from './useLocale';
+
+type FormatNumberDisplayProps = {
+  value: number | bigint;
+  options?: Intl.NumberFormatOptions;
+  testId?: string;
+};
+
+function FormatNumberDisplay({ value, options, testId = 'formatted-value' }: FormatNumberDisplayProps) {
+  const { formatNumber } = useLocale();
+  return <span data-testid={testId}>{formatNumber(value, options)}</span>;
+}
+
+describe('useLocale.formatNumber', () => {
+  beforeEach(async () => {
+    await setTestLanguage('en');
+  });
+
+  it('uses scientific notation when the number exceeds the threshold', () => {
+    renderWithI18n(
+      <FormatNumberDisplay value={1_000_000_000} options={{ maximumFractionDigits: 0 }} />,
+    );
+
+    expect(screen.getByTestId('formatted-value')).toHaveTextContent('1E9');
+  });
+
+  it('formats large bigint values with scientific notation', () => {
+    renderWithI18n(
+      <FormatNumberDisplay
+        value={123_456_789_012_345_678_901_234_567_890n}
+        options={{ maximumFractionDigits: 2 }}
+        testId="bigint-value"
+      />,
+    );
+
+    expect(screen.getByTestId('bigint-value')).toHaveTextContent('1.23E29');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure locale number formatting switches to scientific notation for values at or above 1e9
- cover the formatting logic for both numeric and bigint inputs with new unit tests
- document the scientific notation update in the changelog

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbb770f1108328b398240925da19da