### PR TITLE
Update Finnish daily task reward expiration text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Update the page title to display "suomidle" in browser tabs.
 - Namespace persisted local storage keys by environment to isolate saves across deployments.
 - Move the daily tasks list into a collapsible drawer beneath the settings menu and highlight ready-to-claim tasks.
+- Localize the daily tasks expired reward label to "Bonus käytetty" for Finnish players.
 
 
 ### Fixed

--- a/src/data/daily_tasks.json
+++ b/src/data/daily_tasks.json
@@ -224,7 +224,7 @@
     "completed": "Valmis",
     "claim_reward": "Lunasta tarjous",
     "reward_active": "Päivitys aktiivinen",
-    "reward_expired": "Päivitys päättynyt",
+    "reward_expired": "Bonus käytetty",
     "resets_in": "Uusiutuu",
     "progress": "Edistyminen",
     "of": "/"


### PR DESCRIPTION
## Summary
- translate the Finnish daily task expired reward message to "Bonus käytetty"
- note the localized change in the changelog for upcoming release notes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbbded352083289e16cf1ff144ec84