### PR TITLE
Update Finnish daily task expired bonus translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Move the daily tasks list into a collapsible drawer beneath the settings menu and highlight ready-to-claim tasks.
 - Show the reward each daily task grants and apply active bonuses to the LPS counter in the HUD.
 - Display large numeric values in scientific notation once they exceed 1e9 to improve readability in the UI.
+- Update the Finnish daily tasks expired bonus label to read "Bonus käytetty".
 
 
 ### Fixed

--- a/src/data/daily_tasks.json
+++ b/src/data/daily_tasks.json
@@ -224,7 +224,7 @@
     "completed": "Valmis",
     "claim_reward": "Lunasta tarjous",
     "reward_active": "Päivitys aktiivinen",
-    "reward_expired": "Päivitys päättynyt",
+    "reward_expired": "Bonus käytetty",
     "resets_in": "Uusiutuu",
     "progress": "Edistyminen",
     "of": "/"

--- a/src/i18n/locales/fi/common.json
+++ b/src/i18n/locales/fi/common.json
@@ -22,7 +22,7 @@
   "tasks.daily.toast.duration": "{duration}",
   "tasks.daily.status.completed": "Valmis",
   "tasks.daily.status.active": "Bonus aktiviinen",
-  "tasks.daily.status.expired": "Päivitys päättynyt",
+  "tasks.daily.status.expired": "Bonus käytetty",
   "tasks.daily.status.activeWithTime": "Bonus aktiviinen · {duration}",
   "tasks.daily.reward.tempGain": "Palkinto: +{bonus}% tuotanto · {duration}",
   "tasks.daily.button.progress": "Käynnissä",


### PR DESCRIPTION
## Summary
- update the Finnish daily task expired bonus label to "Bonus käytetty" in the shared data and locale strings
- document the translation change in the changelog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbc93ce06c8328b0ca065fe40e2835