### PR TITLE
Add responsive card grid layout for shop cards

### DIFF
--- a/src/components/BuildingsGrid.tsx
+++ b/src/components/BuildingsGrid.tsx
@@ -18,7 +18,7 @@ export function BuildingsGrid() {
       className="hud hud__card"
       titleClassName="text--h2"
     >
-      <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+      <ul className="card-grid" role="list">
         {buildings.map((b) => {
           if (b.unlock?.tier && tier < b.unlock.tier) return null;
           const count = owned[b.id] || 0;
@@ -27,23 +27,24 @@ export function BuildingsGrid() {
           const disabled = population < price;
           const name = t(`buildings.names.${b.id}` as const, { defaultValue: b.name });
           return (
-            <ImageCardButton
-              key={b.id}
-              icon={`${import.meta.env.BASE_URL}assets/buildings/${b.icon}`}
-              title={t('shop.card.title', {
-                name,
-                count,
-              })}
-              subtitle={t('shop.card.subtitle', {
-                price: formatNumber(price, { maximumFractionDigits: 0 }),
-                cps: formatNumber(cpsDelta, { maximumFractionDigits: 2 }),
-              })}
-              disabled={disabled}
-              onClick={() => buy(b.id)}
-            />
+            <li key={b.id} className="card-grid__item" role="listitem">
+              <ImageCardButton
+                icon={`${import.meta.env.BASE_URL}assets/buildings/${b.icon}`}
+                title={t('shop.card.title', {
+                  name,
+                  count,
+                })}
+                subtitle={t('shop.card.subtitle', {
+                  price: formatNumber(price, { maximumFractionDigits: 0 }),
+                  cps: formatNumber(cpsDelta, { maximumFractionDigits: 2 }),
+                })}
+                disabled={disabled}
+                onClick={() => buy(b.id)}
+              />
+            </li>
           );
         })}
-      </div>
+      </ul>
     </CollapsibleSection>
   );
 }

--- a/src/components/ImageCardButton.tsx
+++ b/src/components/ImageCardButton.tsx
@@ -1,4 +1,3 @@
-
 interface ImageCardButtonProps {
   icon: string;
   title: string;
@@ -18,37 +17,24 @@ export function ImageCardButton({
   className,
   compact,
 }: ImageCardButtonProps) {
+  const buttonClassName = ['card-button', className].filter(Boolean).join(' ');
+
   return (
     <button
-      className={`btn btn--primary ${className ?? ''}`.trim()}
+      type="button"
+      className={buttonClassName}
       onClick={onClick}
       disabled={disabled}
       data-compact={compact ? '' : undefined}
       aria-label={compact ? title : undefined}
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        margin: 4,
-        padding: 8,
-        border: '1px solid #ccc',
-        background: '#fff',
-        opacity: disabled ? 0.5 : 1,
-        cursor: disabled ? 'default' : 'pointer',
-      }}
     >
-      <img
-        src={icon}
-        alt={title}
-        width={compact ? 48 : 96}
-        height={compact ? 48 : 96}
-      />
-      {!compact && (
-        <div className="card__text">
-          <div>{title}</div>
-          {subtitle && <div>{subtitle}</div>}
-        </div>
-      )}
+      <span className="card-button__media" aria-hidden="true">
+        <img src={icon} alt="" loading="lazy" decoding="async" />
+      </span>
+      <span className="card-button__text">
+        <span className="card-button__title">{title}</span>
+        {subtitle && <span className="card-button__subtitle">{subtitle}</span>}
+      </span>
     </button>
   );
 }

--- a/src/components/TechGrid.tsx
+++ b/src/components/TechGrid.tsx
@@ -17,7 +17,7 @@ export function TechGrid() {
       className="hud hud__card"
       titleClassName="text--h2"
     >
-      <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+      <ul className="card-grid" role="list">
         {tech.map((techDef) => {
           const count = counts[techDef.id] || 0;
           const limit = techDef.limit ?? 1;
@@ -35,17 +35,18 @@ export function TechGrid() {
           ].filter(Boolean);
           const name = t(`tech.names.${techDef.id}` as const, { defaultValue: techDef.name });
           return (
-            <ImageCardButton
-              key={techDef.id}
-              icon={`${import.meta.env.BASE_URL}assets/tech/${techDef.icon}`}
-              title={name}
-              subtitle={subtitleParts.join(' · ')}
-              disabled={disabled}
-              onClick={() => buy(techDef.id)}
-            />
+            <li key={techDef.id} className="card-grid__item" role="listitem">
+              <ImageCardButton
+                icon={`${import.meta.env.BASE_URL}assets/tech/${techDef.icon}`}
+                title={name}
+                subtitle={subtitleParts.join(' · ')}
+                disabled={disabled}
+                onClick={() => buy(techDef.id)}
+              />
+            </li>
           );
         })}
-      </div>
+      </ul>
     </CollapsibleSection>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -183,28 +183,135 @@ h1 {
   }
 }
 
-.card {
+.card-grid {
+  --card-grid-gap: 1rem;
+  --card-grid-min-width: 16rem;
+
+  display: grid;
+  grid-template-columns: repeat(
+    auto-fill,
+    minmax(min(var(--card-grid-min-width), 100%), 1fr)
+  );
+  gap: var(--card-grid-gap);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.card-grid__item {
+  display: flex;
+  min-width: 0;
+  list-style: none;
+}
+
+.card-grid__item > * {
+  flex: 1 1 auto;
+}
+
+@media (max-width: 599px) {
+  .card-grid {
+    --card-grid-gap: 0.75rem;
+    --card-grid-min-width: 13rem;
+  }
+}
+
+@media (min-width: 600px) and (max-width: 1023px) {
+  .card-grid {
+    --card-grid-min-width: 15rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .card-grid {
+    --card-grid-min-width: 18rem;
+  }
+}
+
+.card-button {
   display: flex;
   flex-direction: column;
+  justify-content: center;
   align-items: center;
-  margin: 4px;
-  padding: 8px;
-  background-color: var(--surface-elevated);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  border: none;
-  cursor: pointer;
-}
-
-.card:disabled {
-  opacity: 0.5;
-  cursor: default;
-}
-
-.card__text {
+  gap: 0.75rem;
   width: 100%;
-  padding: 4px;
-  background: linear-gradient(to top, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0));
+  padding: 0.85rem;
+  border: 1px solid color-mix(in srgb, var(--color-text) 12%, transparent);
+  border-radius: 0.75rem;
+  background: color-mix(in srgb, var(--surface-elevated) 90%, transparent);
+  color: inherit;
   text-align: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease,
+    background-color 0.2s ease, border-color 0.2s ease;
+  min-height: 100%;
+}
+
+.card-button:hover:not(:disabled),
+.card-button:focus-visible:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+  border-color: color-mix(in srgb, var(--color-text) 24%, transparent);
+}
+
+.card-button:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--color-text) 65%, transparent);
+  outline-offset: 3px;
+}
+
+.card-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+@media (max-width: 599px) {
+  .card-button {
+    gap: 0.5rem;
+    padding: 0.75rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .card-button {
+    padding: 1.25rem;
+  }
+}
+
+.card-button__media {
+  display: grid;
+  place-items: center;
+  width: clamp(3rem, 40%, 6rem);
+  aspect-ratio: 1;
+}
+
+.card-button[data-compact] .card-button__media {
+  width: 3rem;
+}
+
+.card-button__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.card-button__text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  width: 100%;
+}
+
+.card-button__title {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.card-button__subtitle {
+  font-size: 0.875rem;
+  color: color-mix(in srgb, var(--color-text) 75%, transparent);
+}
+
+.card-button[data-compact] .card-button__text {
+  display: none;
 }
 
 .prestige-mobile-info {
@@ -223,7 +330,7 @@ h1 {
     height: 48px;
   }
 
-  .prestige-btn .card__text {
+  .prestige-btn .card-button__text {
     display: none;
   }
 


### PR DESCRIPTION
## Summary
- add a reusable responsive card grid with breakpoint-specific spacing and sizing
- refactor the building and tech grids to use semantic list markup and the shared responsive layout classes
- update the image card button styling so cards size fluidly inside the grid and remain accessible on compact breakpoints

## Testing
- npm run lint
- npm run test *(fails: vite import analysis cannot resolve react-i18next during vitest)*
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68cbe48420bc83289b830e62d50c0594