### PR TITLE
Simplify card buttons and route details through modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Display large numeric values in scientific notation once they exceed 1e9 to improve readability in the UI.
 - Update the Finnish daily tasks expired bonus label to read "Bonus käytetty".
 - Replace the HUD counters with themed progress bars that highlight next tier unlock progress.
+- Refine shop cards to trigger the localized detail modal while leaving the cards focused on name, ownership count, and availability.
 
 
 ### Fixed

--- a/src/components/BuildingsGrid.tsx
+++ b/src/components/BuildingsGrid.tsx
@@ -10,7 +10,7 @@ interface BuildingsGridProps {
 }
 
 export function BuildingsGrid({ onSelect }: BuildingsGridProps) {
-  const { t } = useLocale();
+  const { t, formatNumber } = useLocale();
   const population = useGameStore((s) => s.population);
   const owned = useGameStore((s) => s.buildings);
   const tier = useGameStore((s) => s.tierLevel);
@@ -28,17 +28,18 @@ export function BuildingsGrid({ onSelect }: BuildingsGridProps) {
           const price = getBuildingCost(b, count);
           const canAfford = population >= price;
           const statusKey = canAfford ? 'available' : 'unavailable';
-          const subtitle = t(`cards.status.${statusKey}` as const);
+          const statusLabel = t(`cards.status.${statusKey}` as const);
           const name = t(`buildings.names.${b.id}` as const, { defaultValue: b.name });
+          const countLabel = t('cards.count.owned', {
+            count: formatNumber(count, { maximumFractionDigits: 0 }),
+          });
           return (
             <li key={b.id} className="card-grid__item" role="listitem">
               <ImageCardButton
                 icon={`${import.meta.env.BASE_URL}assets/buildings/${b.icon}`}
-                title={t('shop.card.title', {
-                  name,
-                  count,
-                })}
-                subtitle={subtitle}
+                title={name}
+                countLabel={countLabel}
+                statusLabel={statusLabel}
                 status={statusKey}
                 onSelect={() => onSelect({ kind: 'building', id: b.id })}
               />

--- a/src/components/ImageCardButton.tsx
+++ b/src/components/ImageCardButton.tsx
@@ -1,7 +1,8 @@
 interface ImageCardButtonProps {
   icon: string;
   title: string;
-  subtitle?: string;
+  countLabel?: string;
+  statusLabel?: string;
   disabled?: boolean;
   onSelect?: () => void;
   className?: string;
@@ -12,7 +13,8 @@ interface ImageCardButtonProps {
 export function ImageCardButton({
   icon,
   title,
-  subtitle,
+  countLabel,
+  statusLabel,
   disabled,
   onSelect,
   className,
@@ -35,8 +37,11 @@ export function ImageCardButton({
         <img src={icon} alt="" loading="lazy" decoding="async" />
       </span>
       <span className="card-button__text">
-        <span className="card-button__title">{title}</span>
-        {subtitle && <span className="card-button__subtitle">{subtitle}</span>}
+        <span className="card-button__header">
+          <span className="card-button__title">{title}</span>
+          {countLabel ? <span className="card-button__count">{countLabel}</span> : null}
+        </span>
+        {statusLabel ? <span className="card-button__subtitle">{statusLabel}</span> : null}
       </span>
     </button>
   );

--- a/src/components/PrestigeCard.tsx
+++ b/src/components/PrestigeCard.tsx
@@ -55,9 +55,9 @@ export function PrestigeCard() {
           name: prestigeName,
           value: formatNumber(prestigeMult, { maximumFractionDigits: 2 }),
         })}
-        subtitle={subtitle}
+        statusLabel={subtitle}
         disabled={!canPrestige}
-        onClick={() => {
+        onSelect={() => {
           if (!canPrestige) return;
           if (
             confirm(

--- a/src/components/TechGrid.tsx
+++ b/src/components/TechGrid.tsx
@@ -39,12 +39,22 @@ export function TechGrid({ onSelect }: TechGridProps) {
                 })
               : t(`cards.status.${statusKey}` as const);
           const name = t(`tech.names.${techDef.id}` as const, { defaultValue: techDef.name });
+          const countLabel =
+            limit > 1
+              ? t('cards.count.ownedWithLimit', {
+                  count: formatNumber(count, { maximumFractionDigits: 0 }),
+                  limit: formatNumber(limit, { maximumFractionDigits: 0 }),
+                })
+              : t('cards.count.owned', {
+                  count: formatNumber(count, { maximumFractionDigits: 0 }),
+                });
           return (
             <li key={techDef.id} className="card-grid__item" role="listitem">
               <ImageCardButton
                 icon={`${import.meta.env.BASE_URL}assets/tech/${techDef.icon}`}
                 title={name}
-                subtitle={statusLabel}
+                countLabel={countLabel}
+                statusLabel={statusLabel}
                 status={statusKey}
                 onSelect={() => onSelect({ kind: 'tech', id: techDef.id })}
               />

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -100,6 +100,8 @@
   "cards.status.locked": "Locked",
   "cards.status.lockedTier": "Locked · Tier {tier}",
   "cards.status.owned": "Owned",
+  "cards.count.owned": "{count} owned",
+  "cards.count.ownedWithLimit": "{count} / {limit} owned",
   "shop.permanentMods": "Permanent Modifiers",
   "buildings.names.sauna": "Sauna",
   "buildings.names.kylakauppa": "Village Shop",

--- a/src/i18n/locales/fi/common.json
+++ b/src/i18n/locales/fi/common.json
@@ -100,6 +100,8 @@
   "cards.status.locked": "Lukittu",
   "cards.status.lockedTier": "Lukittu · Taso {tier}",
   "cards.status.owned": "Omistat",
+  "cards.count.owned": "{count} kpl",
+  "cards.count.ownedWithLimit": "{count} / {limit} kpl",
   "shop.permanentMods": "Pysyvät modifikaattorit",
   "buildings.names.sauna": "Sauna",
   "buildings.names.kylakauppa": "Kyläkauppa",

--- a/src/i18n/locales/sv/common.json
+++ b/src/i18n/locales/sv/common.json
@@ -100,6 +100,8 @@
   "cards.status.locked": "Låst",
   "cards.status.lockedTier": "Låst · Nivå {tier}",
   "cards.status.owned": "Ägs",
+  "cards.count.owned": "{count} i ägo",
+  "cards.count.ownedWithLimit": "{count} / {limit} i ägo",
   "shop.permanentMods": "Permanenta modifierare",
   "buildings.names.sauna": "Bastu",
   "buildings.names.kylakauppa": "Bybutik",

--- a/src/index.css
+++ b/src/index.css
@@ -319,9 +319,21 @@ h1 {
   width: 100%;
 }
 
+.card-button__header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.15rem;
+}
+
 .card-button__title {
   font-weight: 600;
   font-size: 1rem;
+}
+
+.card-button__count {
+  font-size: 0.85rem;
+  color: color-mix(in srgb, var(--color-text) 70%, transparent);
 }
 
 .card-button__subtitle {


### PR DESCRIPTION
## Summary
- streamline `ImageCardButton` to surface name, count, and status while delegating long-form copy to the modal
- update building and tech grids to trigger the card details modal with localized count/status labels and refreshed translations
- polish card button styling to handle the new header layout and document the change in the changelog

## Testing
- npm run lint
- npm run test
- npm run check:i18n

------
https://chatgpt.com/codex/tasks/task_e_68cc07a083ac8328b5fac280414f48b5