### PR TITLE
Improve Polta sauna button responsiveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,4 +21,5 @@
 - Prevent GitHub Pages deployments from failing when promoting the root build into the combined artifact.
 - Remove decimals from the Lämpötila counter for clearer progress tracking.
 - Align shop translation interpolations with numeric ICU formatting and fix the Polta Maailma confirmation phrase typing error.
+- Adjust the Polta sauna prestige button layout so it stays within the viewport and remains fully clickable on small screens.
 

--- a/src/components/PrestigeCard.tsx
+++ b/src/components/PrestigeCard.tsx
@@ -37,17 +37,7 @@ export function PrestigeCard() {
       });
 
   return (
-    <div
-      style={{
-        position: 'fixed',
-        top: '1rem',
-        right: '1rem',
-        zIndex: 1000,
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-      }}
-    >
+    <div className="prestige-card">
       <ImageCardButton
         className="prestige-btn"
         icon={prestigeData.icon}

--- a/src/index.css
+++ b/src/index.css
@@ -300,6 +300,18 @@ h1 {
   width: 100%;
 }
 
+.prestige-card {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  width: min(22rem, calc(100vw - 2rem));
+  gap: 0.5rem;
+}
+
 .card-button__title {
   font-weight: 600;
   font-size: 1rem;
@@ -320,6 +332,12 @@ h1 {
 }
 
 @media (max-width: 480px) {
+  .prestige-card {
+    top: 0.75rem;
+    right: 0.75rem;
+    width: calc(100vw - 1.5rem);
+  }
+
   .prestige-btn {
     margin: 2px !important;
     padding: 4px !important;


### PR DESCRIPTION
## Summary
- clamp the prestige card container width so the Polta sauna action stays within the viewport
- stretch the prestige button layout on small screens to keep it fully tappable
- document the responsive layout fix in the changelog

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc5a1d7d508328b9c825ee20d8fea4