### PR TITLE
Add buy-all building purchases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+- Add a "Buy all" option to building shop entries to purchase the maximum affordable amount at once.
 - Daily Tasks system with rotating objectives, persistent progress, and temporary Lämpötila buffs.
 - Configure deployments to publish the `aaroonparas.com` CNAME record.
 - Collapsible controls for the building, technology, tier, and Maailma shops.

--- a/src/app/buildingPurchase.ts
+++ b/src/app/buildingPurchase.ts
@@ -1,0 +1,123 @@
+import type { BuildingDef } from '../content/types';
+import type { PermanentBonuses } from '../effects/applyPermanentBonuses';
+
+const MIN_COST_MULTIPLIER = 0.0001;
+export const BUILDING_PURCHASE_EPSILON = 1e-6;
+
+export interface BuildingPurchaseState {
+  costMultiplier: number;
+  nextPrice: number;
+}
+
+const clampMultiplier = (value: number) =>
+  Number.isFinite(value) ? Math.max(MIN_COST_MULTIPLIER, value) : MIN_COST_MULTIPLIER;
+
+const clampCount = (value: number) => (Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0);
+
+/**
+ * Computes the effective cost multiplier and next purchase price for a building.
+ */
+export const createBuildingPurchaseState = (
+  building: BuildingDef,
+  currentCount: number,
+  permanent: PermanentBonuses,
+): BuildingPurchaseState => {
+  const safeCount = clampCount(currentCount);
+  const baseCostMult = building.costMult + permanent.buildingCostMultiplier.delta;
+  const floor = permanent.buildingCostMultiplier.floor;
+  const adjustedMultiplier =
+    typeof floor === 'number' && Number.isFinite(floor) ? Math.max(baseCostMult, floor) : baseCostMult;
+  const costMultiplier = clampMultiplier(adjustedMultiplier);
+  const nextPriceRaw = building.baseCost * Math.pow(costMultiplier, safeCount);
+  const nextPrice =
+    Number.isFinite(nextPriceRaw) && nextPriceRaw > 0 ? nextPriceRaw : Number.POSITIVE_INFINITY;
+  return { costMultiplier, nextPrice };
+};
+
+const isApproximatelyEqual = (a: number, b: number) => Math.abs(a - b) <= BUILDING_PURCHASE_EPSILON;
+
+/**
+ * Computes the total cost for purchasing a number of buildings using a precomputed state.
+ */
+export const getTotalCostForPurchases = (
+  state: BuildingPurchaseState,
+  additionalCount: number,
+): number => {
+  const count = clampCount(additionalCount);
+  if (count <= 0) return 0;
+  const { costMultiplier, nextPrice } = state;
+  if (!Number.isFinite(nextPrice) || nextPrice <= 0) return Number.POSITIVE_INFINITY;
+  if (isApproximatelyEqual(costMultiplier, 1)) {
+    return nextPrice * count;
+  }
+  const ratioPower = Math.pow(costMultiplier, count);
+  if (!Number.isFinite(ratioPower)) return Number.POSITIVE_INFINITY;
+  return (nextPrice * (ratioPower - 1)) / (costMultiplier - 1);
+};
+
+const searchAffordablePurchases = (
+  state: BuildingPurchaseState,
+  availablePopulation: number,
+): number => {
+  let low = 0;
+  let high = 1;
+  while (high < Number.MAX_SAFE_INTEGER) {
+    const cost = getTotalCostForPurchases(state, high);
+    if (!Number.isFinite(cost) || cost > availablePopulation + BUILDING_PURCHASE_EPSILON) {
+      break;
+    }
+    low = high;
+    if (high >= 1_000_000) {
+      break;
+    }
+    high *= 2;
+  }
+  while (low < high) {
+    const mid = low + Math.floor((high - low + 1) / 2);
+    const cost = getTotalCostForPurchases(state, mid);
+    if (Number.isFinite(cost) && cost <= availablePopulation + BUILDING_PURCHASE_EPSILON) {
+      low = mid;
+    } else {
+      high = mid - 1;
+    }
+  }
+  return low;
+};
+
+/**
+ * Determines how many buildings can be afforded with the available population currency.
+ */
+export const getMaxAffordablePurchases = (
+  state: BuildingPurchaseState,
+  availablePopulation: number,
+): number => {
+  if (!Number.isFinite(availablePopulation) || availablePopulation <= 0) return 0;
+  const { costMultiplier, nextPrice } = state;
+  if (!Number.isFinite(nextPrice) || nextPrice <= 0) return 0;
+  if (availablePopulation + BUILDING_PURCHASE_EPSILON < nextPrice) return 0;
+
+  let maxPurchases = 0;
+  if (isApproximatelyEqual(costMultiplier, 1)) {
+    maxPurchases = Math.floor((availablePopulation + BUILDING_PURCHASE_EPSILON) / nextPrice);
+  } else {
+    const target = 1 + (availablePopulation * (costMultiplier - 1)) / nextPrice;
+    if (target <= 0) {
+      maxPurchases = searchAffordablePurchases(state, availablePopulation);
+    } else {
+      const raw = Math.log(target) / Math.log(costMultiplier);
+      if (Number.isFinite(raw) && raw > 0) {
+        maxPurchases = Math.floor(raw);
+      }
+    }
+  }
+
+  if (maxPurchases <= 0) return 0;
+
+  let totalCost = getTotalCostForPurchases(state, maxPurchases);
+  while (maxPurchases > 0 && (!Number.isFinite(totalCost) || totalCost > availablePopulation + BUILDING_PURCHASE_EPSILON)) {
+    maxPurchases -= 1;
+    totalCost = getTotalCostForPurchases(state, maxPurchases);
+  }
+
+  return maxPurchases > 0 ? maxPurchases : 0;
+};

--- a/src/components/Store.tsx
+++ b/src/components/Store.tsx
@@ -1,42 +1,80 @@
+import {
+  BUILDING_PURCHASE_EPSILON,
+  createBuildingPurchaseState,
+  getMaxAffordablePurchases,
+  getTotalCostForPurchases,
+} from '../app/buildingPurchase';
 import { useGameStore } from '../app/store';
-import { buildings, getBuildingCost } from '../content';
+import { buildings } from '../content';
 import { useLocale } from '../i18n/useLocale';
 
 export function Store() {
   const { t, formatNumber } = useLocale();
   const buy = useGameStore((s) => s.purchaseBuilding);
+  const buyMax = useGameStore((s) => s.purchaseBuildingMax);
   const population = useGameStore((s) => s.population);
   const owned = useGameStore((s) => s.buildings);
   const tier = useGameStore((s) => s.tierLevel);
+  const permanent = useGameStore((s) => s.modifiers.permanent);
   return (
     <div>
       <h2>{t('shop.title')}</h2>
       {buildings.map((building) => {
         if (building.unlock?.tier && tier < building.unlock.tier) return null;
         const count = owned[building.id] || 0;
-        const price = getBuildingCost(building, count);
+        const purchaseState = createBuildingPurchaseState(building, count, permanent);
+        const price = purchaseState.nextPrice;
+        const maxPurchases = getMaxAffordablePurchases(purchaseState, population);
+        const totalCost =
+          maxPurchases > 0 ? getTotalCostForPurchases(purchaseState, maxPurchases) : 0;
+        const canBuyNow =
+          maxPurchases > 0 && Number.isFinite(totalCost) && totalCost <= population + BUILDING_PURCHASE_EPSILON;
         const name = t(`buildings.names.${building.id}` as const, { defaultValue: building.name });
+        const formattedPrice = Number.isFinite(price)
+          ? formatNumber(price, { maximumFractionDigits: 0 })
+          : '—';
+        const formattedBuyAllCost =
+          maxPurchases > 0 && Number.isFinite(totalCost)
+            ? formatNumber(totalCost, { maximumFractionDigits: 0 })
+            : '—';
+        const formattedBuyAllCount = formatNumber(maxPurchases, { maximumFractionDigits: 0 });
         return (
-          <div key={building.id}>
-            <span>
+          <div key={building.id} className="store__item">
+            <span className="store__item-label">
               {t('shop.list.item', {
                 name,
                 count,
               })}
             </span>
-            <button
-              className="btn btn--primary"
-              disabled={population < price}
-              onClick={() => buy(building.id)}
-              aria-label={t('shop.list.buy', {
-                name,
-                price: formatNumber(price, { maximumFractionDigits: 0 }),
-              })}
-            >
-              {t('shop.list.button', {
-                price: formatNumber(price, { maximumFractionDigits: 0 }),
-              })}
-            </button>
+            <div className="store__actions">
+              <button
+                className="btn btn--primary"
+                disabled={!canBuyNow}
+                onClick={() => buy(building.id)}
+                aria-label={t('shop.list.buy', {
+                  name,
+                  price: formattedPrice,
+                })}
+              >
+                {t('shop.list.button', {
+                  price: formattedPrice,
+                })}
+              </button>
+              <button
+                className="btn btn--secondary"
+                disabled={!canBuyNow}
+                onClick={() => buyMax(building.id)}
+                aria-label={t('shop.list.buyAll', {
+                  name,
+                  count: formattedBuyAllCount,
+                  price: formattedBuyAllCost,
+                })}
+              >
+                {t('shop.list.buttonAll', {
+                  count: formattedBuyAllCount,
+                })}
+              </button>
+            </div>
           </div>
         );
       })}

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -85,6 +85,8 @@
   "shop.list.item": "{name} ({count, number})",
   "shop.list.buy": "Buy {name} for {price}",
   "shop.list.button": "Buy {price}",
+  "shop.list.buyAll": "Buy all available {name} ({count}) for {price}",
+  "shop.list.buttonAll": "Buy all ({count})",
   "shop.permanentMods": "Permanent Modifiers",
   "buildings.names.sauna": "Sauna",
   "buildings.names.kylakauppa": "Village Shop",

--- a/src/i18n/locales/fi/common.json
+++ b/src/i18n/locales/fi/common.json
@@ -85,6 +85,8 @@
   "shop.list.item": "{name} ({count, number})",
   "shop.list.buy": "Osta {name} hintaan {price}",
   "shop.list.button": "Osta {price}",
+  "shop.list.buyAll": "Osta kaikki {name} ({count}) hintaan {price}",
+  "shop.list.buttonAll": "Osta kaikki ({count})",
   "shop.permanentMods": "Pysyvät modifikaattorit",
   "buildings.names.sauna": "Sauna",
   "buildings.names.kylakauppa": "Kyläkauppa",

--- a/src/i18n/locales/sv/common.json
+++ b/src/i18n/locales/sv/common.json
@@ -85,6 +85,8 @@
   "shop.list.item": "{name} ({count, number})",
   "shop.list.buy": "Köp {name} för {price}",
   "shop.list.button": "Köp {price}",
+  "shop.list.buyAll": "Köp alla {name} ({count}) för {price}",
+  "shop.list.buttonAll": "Köp alla ({count})",
   "shop.permanentMods": "Permanenta modifierare",
   "buildings.names.sauna": "Bastu",
   "buildings.names.kylakauppa": "Bybutik",

--- a/src/index.css
+++ b/src/index.css
@@ -58,6 +58,11 @@ h1 {
   color: var(--color-button-text);
 }
 
+.btn--secondary {
+  background-color: color-mix(in srgb, var(--brand-primary) 25%, transparent);
+  color: var(--color-button-text);
+}
+
 .btn--success {
   background-color: #2f9e44;
   color: var(--color-button-text);
@@ -73,9 +78,18 @@ h1 {
   opacity: 0.75;
 }
 
+.btn--secondary:disabled {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.55);
+  cursor: not-allowed;
+}
+
 .btn--primary:hover,
 .btn--primary:active,
-.btn--primary:focus-visible {
+.btn--primary:focus-visible,
+.btn--secondary:hover,
+.btn--secondary:active,
+.btn--secondary:focus-visible {
   outline: 2px solid var(--color-text);
   outline-offset: 2px;
 }
@@ -118,6 +132,27 @@ h1 {
   justify-content: space-between;
   gap: 0.75rem;
   flex-wrap: wrap;
+}
+
+.store__item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.store__item-label {
+  flex: 1 1 12rem;
+  text-align: left;
+}
+
+.store__actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .collapsible__toggle {


### PR DESCRIPTION
## Summary
- add building cost utilities that compute effective prices and maximum affordable building purchases
- expose a new `purchaseBuildingMax` action with a "Buy all" control in the shop UI, including styling and localized strings
- extend the store tests and changelog coverage for the bulk-purchase behaviour

## Testing
- npm run lint
- npm test
- npm run check:i18n

------
https://chatgpt.com/codex/tasks/task_e_68cc5aee07b083288df35d6775d66e42