### PR TITLE
Polish store buy all experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Move the daily tasks list into a collapsible drawer beneath the settings menu and highlight ready-to-claim tasks.
 - Show the reward each daily task grants and apply active bonuses to the LPS counter in the HUD.
 - Display large numeric values in scientific notation once they exceed 1e9 to improve readability in the UI.
+- Surface a contextual "Buy all" summary and tooltips in the store for clearer bulk purchases.
 - Update the Finnish daily tasks expired bonus label to read "Bonus käytetty".
 
 

--- a/src/components/Store.tsx
+++ b/src/components/Store.tsx
@@ -38,6 +38,19 @@ export function Store() {
             ? formatNumber(totalCost, { maximumFractionDigits: 0 })
             : '—';
         const formattedBuyAllCount = formatNumber(maxPurchases, { maximumFractionDigits: 0 });
+        const buyLabel = t('shop.list.button', {
+          price: formattedPrice,
+        });
+        const buyDescription = t('shop.list.buy', {
+          name,
+          price: formattedPrice,
+        });
+        const buyAllDescription = t('shop.list.buyAll', {
+          name,
+          formattedCount: formattedBuyAllCount,
+          price: formattedBuyAllCost,
+        });
+        const showMaxPurchaseHint = maxPurchases > 1 && Number.isFinite(totalCost);
         return (
           <div key={building.id} className="store__item">
             <span className="store__item-label">
@@ -47,33 +60,36 @@ export function Store() {
               })}
             </span>
             <div className="store__actions">
-              <button
-                className="btn btn--primary"
-                disabled={!canBuyNow}
-                onClick={() => buy(building.id)}
-                aria-label={t('shop.list.buy', {
-                  name,
-                  price: formattedPrice,
-                })}
-              >
-                {t('shop.list.button', {
-                  price: formattedPrice,
-                })}
-              </button>
-              <button
-                className="btn btn--secondary"
-                disabled={!canBuyNow}
-                onClick={() => buyMax(building.id)}
-                aria-label={t('shop.list.buyAll', {
-                  name,
-                  formattedCount: formattedBuyAllCount,
-                  price: formattedBuyAllCost,
-                })}
-              >
-                {t('shop.list.buttonAll', {
-                  formattedCount: formattedBuyAllCount,
-                })}
-              </button>
+              <div className="store__button-group">
+                <button
+                  className="btn btn--primary"
+                  disabled={!canBuyNow}
+                  onClick={() => buy(building.id)}
+                  aria-label={buyDescription}
+                  title={buyDescription}
+                >
+                  {buyLabel}
+                </button>
+                <button
+                  className="btn btn--secondary"
+                  disabled={!canBuyNow}
+                  onClick={() => buyMax(building.id)}
+                  aria-label={buyAllDescription}
+                  title={buyAllDescription}
+                >
+                  {t('shop.list.buttonAll', {
+                    formattedCount: formattedBuyAllCount,
+                  })}
+                </button>
+              </div>
+              {showMaxPurchaseHint ? (
+                <p className="store__hint" role="status">
+                  {t('shop.list.maxPurchaseHint', {
+                    formattedCount: formattedBuyAllCount,
+                    price: formattedBuyAllCost,
+                  })}
+                </p>
+              ) : null}
             </div>
           </div>
         );

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -87,6 +87,7 @@
   "shop.list.button": "Buy {price}",
   "shop.list.buyAll": "Buy all available {name} ({formattedCount}) for {price}",
   "shop.list.buttonAll": "Buy all ({formattedCount})",
+  "shop.list.maxPurchaseHint": "Max purchase: {formattedCount} for {price}",
   "shop.permanentMods": "Permanent Modifiers",
   "buildings.names.sauna": "Sauna",
   "buildings.names.kylakauppa": "Village Shop",

--- a/src/i18n/locales/fi/common.json
+++ b/src/i18n/locales/fi/common.json
@@ -87,6 +87,7 @@
   "shop.list.button": "Osta {price}",
   "shop.list.buyAll": "Osta kaikki {name} ({formattedCount}) hintaan {price}",
   "shop.list.buttonAll": "Osta kaikki ({formattedCount})",
+  "shop.list.maxPurchaseHint": "Suurin mahdollinen ostos: {formattedCount} hintaan {price}",
   "shop.permanentMods": "Pysyvät modifikaattorit",
   "buildings.names.sauna": "Sauna",
   "buildings.names.kylakauppa": "Kyläkauppa",

--- a/src/i18n/locales/sv/common.json
+++ b/src/i18n/locales/sv/common.json
@@ -87,6 +87,7 @@
   "shop.list.button": "Köp {price}",
   "shop.list.buyAll": "Köp alla {name} ({formattedCount}) för {price}",
   "shop.list.buttonAll": "Köp alla ({formattedCount})",
+  "shop.list.maxPurchaseHint": "Maxköp: {formattedCount} för {price}",
   "shop.permanentMods": "Permanenta modifierare",
   "buildings.names.sauna": "Bastu",
   "buildings.names.kylakauppa": "Bybutik",

--- a/src/index.css
+++ b/src/index.css
@@ -150,9 +150,23 @@ h1 {
 
 .store__actions {
   display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
+}
+
+.store__button-group {
+  display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
   justify-content: flex-end;
+}
+
+.store__hint {
+  font-size: 0.85rem;
+  color: color-mix(in srgb, var(--color-text) 70%, transparent);
+  text-align: right;
+  margin: 0;
 }
 
 .collapsible__toggle {


### PR DESCRIPTION
## Summary
- add contextual tooltips and aria descriptions to the store buy controls
- show a max purchase helper beneath "Buy all" with translated copy and refreshed layout
- adjust store action styles to accommodate the hint while keeping buttons aligned

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cc819008f48328b526f0b15588cc78