### PR TITLE
Show Buy all control in building grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,4 +25,5 @@
 - Align shop translation interpolations with numeric ICU formatting and fix the Polta Maailma confirmation phrase typing error.
 - Adjust the Polta sauna prestige button layout so it stays within the viewport and remains fully clickable on small screens.
 - Fix the store "Buy all" translations to use formatted counts so the TypeScript build completes successfully.
+- Render the building shop bulk purchase button so the "Buy all" option is visible in the card grid UI.
 

--- a/src/components/BuildingsGrid.tsx
+++ b/src/components/BuildingsGrid.tsx
@@ -1,5 +1,11 @@
+import {
+  BUILDING_PURCHASE_EPSILON,
+  createBuildingPurchaseState,
+  getMaxAffordablePurchases,
+  getTotalCostForPurchases,
+} from '../app/buildingPurchase';
 import { useGameStore } from '../app/store';
-import { buildings, getBuildingCost } from '../content';
+import { buildings } from '../content';
 import { useLocale } from '../i18n/useLocale';
 import { CollapsibleSection } from './CollapsibleSection';
 import { ImageCardButton } from './ImageCardButton';
@@ -7,10 +13,12 @@ import { ImageCardButton } from './ImageCardButton';
 export function BuildingsGrid() {
   const { t, formatNumber } = useLocale();
   const buy = useGameStore((s) => s.purchaseBuilding);
+  const buyMax = useGameStore((s) => s.purchaseBuildingMax);
   const population = useGameStore((s) => s.population);
   const owned = useGameStore((s) => s.buildings);
   const tier = useGameStore((s) => s.tierLevel);
   const mult = useGameStore((s) => s.multipliers.population_cps);
+  const permanent = useGameStore((s) => s.modifiers.permanent);
 
   return (
     <CollapsibleSection
@@ -22,25 +30,86 @@ export function BuildingsGrid() {
         {buildings.map((b) => {
           if (b.unlock?.tier && tier < b.unlock.tier) return null;
           const count = owned[b.id] || 0;
-          const price = getBuildingCost(b, count);
+          const purchaseState = createBuildingPurchaseState(b, count, permanent);
+          const price = purchaseState.nextPrice;
           const cpsDelta = b.baseProd * mult;
-          const disabled = population < price;
+          const rawMaxPurchases = getMaxAffordablePurchases(purchaseState, population);
+          const maxPurchases = Number.isFinite(rawMaxPurchases)
+            ? rawMaxPurchases
+            : 0;
+          const totalCost =
+            maxPurchases > 0 ? getTotalCostForPurchases(purchaseState, maxPurchases) : 0;
           const name = t(`buildings.names.${b.id}` as const, { defaultValue: b.name });
+          const formattedPrice = Number.isFinite(price)
+            ? formatNumber(price, { maximumFractionDigits: 0 })
+            : '—';
+          const formattedCps = formatNumber(cpsDelta, { maximumFractionDigits: 2 });
+          const formattedBuyAllCount = formatNumber(maxPurchases, { maximumFractionDigits: 0 });
+          const hasFiniteTotalCost = maxPurchases > 0 && Number.isFinite(totalCost);
+          const formattedBuyAllCost = hasFiniteTotalCost
+            ? formatNumber(totalCost, { maximumFractionDigits: 0 })
+            : '—';
+          const canBuySingle =
+            Number.isFinite(price) &&
+            price > 0 &&
+            population + BUILDING_PURCHASE_EPSILON >= price;
+          const canBuyBulk =
+            maxPurchases > 0 &&
+            hasFiniteTotalCost &&
+            totalCost <= population + BUILDING_PURCHASE_EPSILON;
+          const buyDescription = t('shop.list.buy', {
+            name,
+            price: formattedPrice,
+          });
+          const buyAllDescription = t('shop.list.buyAll', {
+            name,
+            formattedCount: formattedBuyAllCount,
+            price: formattedBuyAllCost,
+          });
+          const buyAllLabel = t('shop.list.buttonAll', {
+            formattedCount: formattedBuyAllCount,
+          });
+          const showMaxPurchaseHint = maxPurchases > 1 && hasFiniteTotalCost;
           return (
             <li key={b.id} className="card-grid__item" role="listitem">
-              <ImageCardButton
-                icon={`${import.meta.env.BASE_URL}assets/buildings/${b.icon}`}
-                title={t('shop.card.title', {
-                  name,
-                  count,
-                })}
-                subtitle={t('shop.card.subtitle', {
-                  price: formatNumber(price, { maximumFractionDigits: 0 }),
-                  cps: formatNumber(cpsDelta, { maximumFractionDigits: 2 }),
-                })}
-                disabled={disabled}
-                onClick={() => buy(b.id)}
-              />
+              <article className="building-card">
+                <ImageCardButton
+                  className="building-card__buy-one"
+                  icon={`${import.meta.env.BASE_URL}assets/buildings/${b.icon}`}
+                  title={t('shop.card.title', {
+                    name,
+                    count,
+                  })}
+                  subtitle={t('shop.card.subtitle', {
+                    price: formattedPrice,
+                    cps: formattedCps,
+                  })}
+                  disabled={!canBuySingle}
+                  onClick={() => buy(b.id)}
+                  ariaLabel={buyDescription}
+                  tooltip={buyDescription}
+                />
+                <div className="building-card__actions">
+                  <button
+                    type="button"
+                    className="btn btn--secondary building-card__buy-all"
+                    disabled={!canBuyBulk}
+                    onClick={() => buyMax(b.id)}
+                    aria-label={buyAllDescription}
+                    title={buyAllDescription}
+                  >
+                    {buyAllLabel}
+                  </button>
+                  {showMaxPurchaseHint ? (
+                    <p className="building-card__hint" role="status">
+                      {t('shop.list.maxPurchaseHint', {
+                        formattedCount: formattedBuyAllCount,
+                        price: formattedBuyAllCost,
+                      })}
+                    </p>
+                  ) : null}
+                </div>
+              </article>
             </li>
           );
         })}

--- a/src/components/ImageCardButton.tsx
+++ b/src/components/ImageCardButton.tsx
@@ -6,6 +6,8 @@ interface ImageCardButtonProps {
   onClick: () => void;
   className?: string;
   compact?: boolean;
+  ariaLabel?: string;
+  tooltip?: string;
 }
 
 export function ImageCardButton({
@@ -16,8 +18,12 @@ export function ImageCardButton({
   onClick,
   className,
   compact,
+  ariaLabel,
+  tooltip,
 }: ImageCardButtonProps) {
   const buttonClassName = ['card-button', className].filter(Boolean).join(' ');
+  const computedAriaLabel = ariaLabel ?? (compact ? title : undefined);
+  const computedTitle = tooltip ?? (compact ? title : undefined);
 
   return (
     <button
@@ -26,7 +32,8 @@ export function ImageCardButton({
       onClick={onClick}
       disabled={disabled}
       data-compact={compact ? '' : undefined}
-      aria-label={compact ? title : undefined}
+      aria-label={computedAriaLabel}
+      title={computedTitle}
     >
       <span className="card-button__media" aria-hidden="true">
         <img src={icon} alt="" loading="lazy" decoding="async" />

--- a/src/index.css
+++ b/src/index.css
@@ -257,6 +257,35 @@ h1 {
   flex: 1 1 auto;
 }
 
+.building-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: 100%;
+}
+
+.building-card__buy-one {
+  width: 100%;
+}
+
+.building-card__actions {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.35rem;
+}
+
+.building-card__buy-all {
+  width: 100%;
+}
+
+.building-card__hint {
+  font-size: 0.85rem;
+  color: color-mix(in srgb, var(--color-text) 70%, transparent);
+  text-align: center;
+  margin: 0;
+}
+
 @media (max-width: 599px) {
   .card-grid {
     --card-grid-gap: 0.75rem;

--- a/src/tests/buildingsGrid.test.tsx
+++ b/src/tests/buildingsGrid.test.tsx
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { BuildingsGrid } from '../components/BuildingsGrid';
+import { useGameStore } from '../app/store';
+import { renderWithI18n, setTestLanguage } from './testUtils';
+import { createInitialDailyTasksState } from '../systems/dailyTasks';
+
+const BUY_ALL_LABEL_REGEX = /Buy all/i;
+
+describe('BuildingsGrid', () => {
+  beforeEach(async () => {
+    await setTestLanguage('en');
+    useGameStore.persist.clearStorage();
+    useGameStore.setState({
+      population: 0,
+      totalPopulation: 0,
+      tierLevel: 1,
+      buildings: {},
+      techCounts: {},
+      multipliers: { population_cps: 1 },
+      cps: 0,
+      clickPower: 1,
+      prestigePoints: 0,
+      prestigeMult: 1,
+      eraMult: 1,
+      dailyTasks: createInitialDailyTasksState(),
+    });
+    useGameStore.getState().recompute();
+  });
+
+  it('shows an enabled Buy all button when the player can afford multiple buildings', () => {
+    useGameStore.setState({ population: 1000 });
+    useGameStore.getState().recompute();
+    renderWithI18n(<BuildingsGrid />);
+    const [buyAllButton] = screen.getAllByRole('button', { name: BUY_ALL_LABEL_REGEX });
+    expect(buyAllButton).toBeEnabled();
+  });
+
+  it('disables the Buy all button when no bulk purchase is affordable', () => {
+    renderWithI18n(<BuildingsGrid />);
+    const [buyAllButton] = screen.getAllByRole('button', { name: BUY_ALL_LABEL_REGEX });
+    expect(buyAllButton).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary
- render the Buy all bulk purchase control inside each building card and wire it to the max-buy logic
- add accessibility hooks and styling so the secondary action and hint fit the card grid layout
- cover the new bulk purchase button with unit tests and document the fix in the changelog

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd0603eef0832881b0e144f1fc4cdb