### PR TITLE
Fix building shop buy-all button layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,4 +26,5 @@
 - Adjust the Polta sauna prestige button layout so it stays within the viewport and remains fully clickable on small screens.
 - Fix the store "Buy all" translations to use formatted counts so the TypeScript build completes successfully.
 - Render the building shop bulk purchase button so the "Buy all" option is visible in the card grid UI.
+- Keep the building shop "Buy all" controls above the grid so they are never hidden behind neighbouring cards.
 

--- a/src/index.css
+++ b/src/index.css
@@ -258,14 +258,17 @@ h1 {
 }
 
 .building-card {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
   gap: 0.5rem;
   width: 100%;
+  height: 100%;
 }
 
 .building-card__buy-one {
   width: 100%;
+  height: 100%;
+  align-self: stretch;
 }
 
 .building-card__actions {
@@ -273,6 +276,8 @@ h1 {
   flex-direction: column;
   align-items: stretch;
   gap: 0.35rem;
+  position: relative;
+  z-index: 1;
 }
 
 .building-card__buy-all {
@@ -321,7 +326,6 @@ h1 {
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease,
     background-color 0.2s ease, border-color 0.2s ease;
-  min-height: 100%;
 }
 
 .card-button:hover:not(:disabled),


### PR DESCRIPTION
## Summary
- update the building card layout so the bulk purchase actions stay visible above neighbouring grid items
- drop the old card button min-height to prevent content from overlapping the action area
- record the UI fix in the changelog

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd0d8275ac83288bdd9ad8a640eec2