### PR TITLE
Improve mobile layouts for Polta sauna and daily tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - Display large numeric values in scientific notation once they exceed 1e9 to improve readability in the UI.
 - Surface a contextual "Buy all" summary and tooltips in the store for clearer bulk purchases.
 - Update the Finnish daily tasks expired bonus label to read "Bonus käytetty".
+- Refine the Polta sauna action button, modal, and toast styling so the prestige flow stays accessible on phones.
+- Rework the daily tasks drawer spacing and cards to better fit smaller mobile viewports without overlapping other HUD controls.
 
 
 ### Fixed

--- a/src/ui/PoltaMaailmaButton.css
+++ b/src/ui/PoltaMaailmaButton.css
@@ -1,0 +1,209 @@
+.polta-maailma {
+  position: fixed;
+  bottom: calc(env(safe-area-inset-bottom) + 1.25rem);
+  right: 1.25rem;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
+}
+
+.polta-maailma__button {
+  background: #b91c1c;
+  color: #fff;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  text-align: left;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+  padding: 0.65rem 1rem;
+  min-width: 15rem;
+}
+
+.polta-maailma__button:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.polta-maailma__button:hover,
+.polta-maailma__button:focus-visible {
+  background: #dc2626;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.28);
+}
+
+.polta-maailma__label {
+  font-weight: 600;
+}
+
+.polta-maailma__preview {
+  font-size: 0.85rem;
+  opacity: 0.95;
+}
+
+.polta-maailma__total {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.polta-maailma__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1100;
+  padding: 1rem;
+}
+
+.polta-maailma__dialog {
+  background: var(--surface-elevated);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  max-width: 420px;
+  width: 100%;
+  color: var(--color-text);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.polta-maailma__title {
+  margin: 0;
+}
+
+.polta-maailma__description {
+  margin: 0;
+}
+
+.polta-maailma__stats {
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.polta-maailma__label-text {
+  display: block;
+  margin-bottom: 0.25rem;
+  font-weight: 600;
+}
+
+.polta-maailma__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.polta-maailma__cancel {
+  background: rgba(255, 255, 255, 0.12);
+  color: inherit;
+}
+
+.polta-maailma__confirm {
+  background: #16a34a;
+  color: #fff;
+}
+
+.polta-maailma__confirm:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.polta-maailma__input {
+  width: 100%;
+  padding: 0.65rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(0, 0, 0, 0.35);
+  color: inherit;
+  margin-bottom: 1rem;
+}
+
+.polta-maailma__toast {
+  position: fixed;
+  bottom: calc(env(safe-area-inset-bottom) + 1.25rem);
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(28, 28, 28, 0.9);
+  color: #fff;
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4);
+  z-index: 1200;
+  max-width: 90vw;
+  text-align: center;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 768px) {
+  .polta-maailma {
+    left: auto;
+    right: 0.85rem;
+    transform: none;
+    width: min(360px, calc(100vw - 1.7rem));
+    align-items: stretch;
+    gap: 0.5rem;
+  }
+
+  .polta-maailma__button {
+    width: 100%;
+    min-width: 0;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.85rem 1.15rem;
+    font-size: 1rem;
+    text-align: center;
+  }
+
+  .polta-maailma__total {
+    text-align: center;
+  }
+
+  .polta-maailma__overlay {
+    padding: 1.25rem;
+  }
+
+  .polta-maailma__dialog {
+    max-width: min(480px, calc(100vw - 2rem));
+    padding: 1.25rem;
+  }
+
+  .polta-maailma__actions {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .polta-maailma__toast {
+    padding-inline: 1.25rem;
+    font-size: 0.9rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .polta-maailma {
+    right: 0.65rem;
+    width: min(320px, calc(100vw - 1.3rem));
+    bottom: calc(env(safe-area-inset-bottom) + 0.85rem);
+  }
+
+  .polta-maailma__button {
+    padding: 0.85rem 1rem;
+    font-size: 0.95rem;
+  }
+
+  .polta-maailma__preview {
+    font-size: 0.8rem;
+  }
+
+  .polta-maailma__total {
+    font-size: 0.7rem;
+  }
+
+  .polta-maailma__dialog {
+    gap: 0.85rem;
+  }
+}

--- a/src/ui/PoltaMaailmaButton.tsx
+++ b/src/ui/PoltaMaailmaButton.tsx
@@ -7,6 +7,7 @@ import {
   type TuhkaAwardPreview,
 } from '../app/store';
 import { useLocale } from '../i18n/useLocale';
+import './PoltaMaailmaButton.css';
 
 const toastDurationMs = 5000;
 
@@ -91,40 +92,24 @@ export function PoltaMaailmaButton() {
 
   return (
     <>
-      <div
-        style={{
-          position: 'fixed',
-          bottom: '1.25rem',
-          right: '1.25rem',
-          zIndex: 1000,
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'flex-end',
-          gap: '0.35rem',
-        }}
-      >
+      <div className="polta-maailma">
         <button
           type="button"
-          className="btn btn--primary"
+          className="btn polta-maailma__button"
           onClick={() => setModalOpen(true)}
           disabled={!canPoltaMaailma}
           title={disabledTooltip}
-          style={{
-            background: '#b91c1c',
-            color: '#fff',
-            boxShadow: '0 4px 12px rgba(0,0,0,0.2)',
-          }}
           aria-label={t('maailma.action')}
         >
-          <div style={{ fontWeight: 600 }}>{t('maailma.action')}</div>
-          <div style={{ fontSize: '0.85rem', marginTop: '0.25rem' }}>
+          <span className="polta-maailma__label">{t('maailma.action')}</span>
+          <span className="polta-maailma__preview">
             {t('maailma.preview.gain', {
               award: formatBigInt(preview.award),
               available: formatBigInt(preview.availableAfter),
             })}
-          </div>
+          </span>
         </button>
-        <div style={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.75)' }}>
+        <div className="polta-maailma__total">
           {t('maailma.preview.total', {
             total: formatBigInt(preview.totalEarned),
             totalAfter: formatBigInt(preview.totalEarnedAfter),
@@ -135,17 +120,7 @@ export function PoltaMaailmaButton() {
       {isModalOpen && (
         <div
           role="presentation"
-          style={{
-            position: 'fixed',
-            inset: 0,
-            background: 'rgba(0, 0, 0, 0.6)',
-            backdropFilter: 'blur(2px)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            zIndex: 1100,
-            padding: '1rem',
-          }}
+          className="polta-maailma__overlay"
           onClick={() => {
             setModalOpen(false);
             setConfirmValue('');
@@ -157,30 +132,15 @@ export function PoltaMaailmaButton() {
             aria-labelledby="polta-maailma-title"
             aria-describedby="polta-maailma-description"
             onClick={(event) => event.stopPropagation()}
-            style={{
-              background: 'var(--surface-elevated)',
-              borderRadius: '0.75rem',
-              padding: '1.5rem',
-              maxWidth: '420px',
-              width: '100%',
-              color: 'var(--color-text)',
-              boxShadow: '0 10px 30px rgba(0,0,0,0.35)',
-            }}
+            className="polta-maailma__dialog"
           >
-            <h2 id="polta-maailma-title" style={{ marginTop: 0 }}>
+            <h2 id="polta-maailma-title" className="polta-maailma__title">
               {t('maailma.action')}
             </h2>
-            <p id="polta-maailma-description" style={{ marginBottom: '1rem' }}>
+            <p id="polta-maailma-description" className="polta-maailma__description">
               {t('maailma.description', { phrase: confirmPhrase })}
             </p>
-            <div
-              style={{
-                display: 'grid',
-                gap: '0.5rem',
-                marginBottom: '1rem',
-                fontSize: '0.9rem',
-              }}
-            >
+            <div className="polta-maailma__stats">
               <div>{t('maailma.modal.award', { value: formatBigInt(preview.award) })}</div>
               <div>
                 {t('maailma.modal.available', {
@@ -201,7 +161,7 @@ export function PoltaMaailmaButton() {
                 handleConfirm();
               }}
             >
-              <label htmlFor="polta-maailma-confirm" style={{ display: 'block', marginBottom: '0.25rem' }}>
+              <label htmlFor="polta-maailma-confirm" className="polta-maailma__label-text">
                 {t('maailma.modal.label')}
               </label>
               <input
@@ -210,35 +170,25 @@ export function PoltaMaailmaButton() {
                 value={confirmValue}
                 onChange={(event) => setConfirmValue(event.target.value)}
                 placeholder={confirmPhrase}
-                style={{
-                  width: '100%',
-                  padding: '0.65rem',
-                  borderRadius: '0.5rem',
-                  border: '1px solid rgba(255,255,255,0.2)',
-                  background: 'rgba(0, 0, 0, 0.35)',
-                  color: 'inherit',
-                  marginBottom: '1rem',
-                }}
+                className="polta-maailma__input"
                 autoComplete="off"
                 spellCheck={false}
               />
-              <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
+              <div className="polta-maailma__actions">
                 <button
                   type="button"
-                  className="btn"
+                  className="btn polta-maailma__cancel"
                   onClick={() => {
                     setModalOpen(false);
                     setConfirmValue('');
                   }}
-                  style={{ background: 'rgba(255, 255, 255, 0.12)', color: 'inherit' }}
                 >
                   {t('actions.cancel')}
                 </button>
                 <button
                   type="submit"
-                  className="btn btn--primary"
+                  className="btn polta-maailma__confirm"
                   disabled={confirmValue.trim().toUpperCase() !== confirmPhrase.toUpperCase()}
-                  style={{ background: '#16a34a' }}
                 >
                   {t('actions.confirm')}
                 </button>
@@ -249,25 +199,7 @@ export function PoltaMaailmaButton() {
       )}
 
       {toastMessage && (
-        <div
-          role="status"
-          aria-live="polite"
-          style={{
-            position: 'fixed',
-            bottom: '1.25rem',
-            left: '50%',
-            transform: 'translateX(-50%)',
-            background: 'rgba(28, 28, 28, 0.9)',
-            color: '#fff',
-            padding: '0.75rem 1rem',
-            borderRadius: '999px',
-            boxShadow: '0 6px 18px rgba(0,0,0,0.4)',
-            zIndex: 1200,
-            maxWidth: '90vw',
-            textAlign: 'center',
-            fontSize: '0.95rem',
-          }}
-        >
+        <div role="status" aria-live="polite" className="polta-maailma__toast">
           {toastMessage}
         </div>
       )}

--- a/src/ui/dailyTasks.css
+++ b/src/ui/dailyTasks.css
@@ -234,13 +234,109 @@
   }
 }
 
-@media (max-width: 480px) {
+@media (max-width: 768px) {
   .daily-tasks-drawer {
-    top: calc(28px + 1rem);
+    top: auto;
+    bottom: calc(env(safe-area-inset-bottom) + 5.25rem);
+    left: 50%;
+    transform: translateX(-50%);
+    width: min(440px, calc(100vw - 1.25rem));
+    align-items: center;
+  }
+
+  .daily-tasks-drawer__toggle {
+    width: 100%;
+    justify-content: center;
+    padding: 0.6rem 1rem;
+    box-shadow: 0 6px 22px rgba(0, 0, 0, 0.4);
+  }
+
+  .daily-tasks-drawer__label {
+    font-size: 0.95rem;
   }
 
   .daily-tasks {
-    width: min(320px, calc(100vw - 1rem));
-    max-height: calc(100vh - 7rem);
+    width: 100%;
+    max-width: 440px;
+    max-height: min(60vh, calc(100vh - 7rem));
+    padding: 1.1rem;
+  }
+
+  .daily-tasks__header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.35rem;
+  }
+
+  .daily-tasks__title {
+    text-align: center;
+  }
+
+  .daily-tasks__reset {
+    text-align: center;
+  }
+
+  .daily-tasks__card-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .daily-tasks__status {
+    align-self: flex-start;
+  }
+
+  .daily-tasks__toast {
+    align-self: center;
+    margin-left: 0;
+    width: min(100%, 20rem);
+    text-align: center;
+  }
+}
+
+@media (max-width: 480px) {
+  .daily-tasks-drawer {
+    width: min(360px, calc(100vw - 1rem));
+    bottom: calc(env(safe-area-inset-bottom) + 4.75rem);
+  }
+
+  .daily-tasks-drawer__toggle {
+    padding: 0.65rem 0.9rem;
+    font-size: 0.95rem;
+  }
+
+  .daily-tasks {
+    max-width: none;
+    width: min(100%, calc(100vw - 0.75rem));
+    max-height: min(70vh, calc(100vh - 5.5rem));
+    padding: 1rem;
+  }
+
+  .daily-tasks__card {
+    padding: 0.85rem;
+  }
+
+  .daily-tasks__card-header {
+    gap: 0.5rem;
+  }
+
+  .daily-tasks__card-title {
+    font-size: 1rem;
+  }
+
+  .daily-tasks__card-desc {
+    font-size: 0.85rem;
+  }
+
+  .daily-tasks__reward {
+    font-size: 0.75rem;
+  }
+
+  .daily-tasks__progress-label {
+    font-size: 0.75rem;
+  }
+
+  .daily-tasks__toast {
+    width: min(100%, calc(100vw - 2rem));
+    font-size: 0.8rem;
   }
 }


### PR DESCRIPTION
## Summary
- restyle the Polta sauna action button, confirmation modal, and toast with dedicated CSS for better mobile alignment
- adjust the daily tasks drawer spacing and card layout to avoid overlapping the Polta controls on phones
- document the responsive layout refinements in the changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd26201bfc8328a84f1bf59a1606d4