### PR TITLE
Shrink Polta sauna button on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Remove decimals from the Lämpötila counter for clearer progress tracking.
 - Align shop translation interpolations with numeric ICU formatting and fix the Polta Maailma confirmation phrase typing error.
 - Adjust the Polta sauna prestige button layout so it stays within the viewport and remains fully clickable on small screens.
+- Shrink the Polta sauna prestige button on phones so it doesn't overwhelm the mobile interface.
 - Fix the store "Buy all" translations to use formatted counts so the TypeScript build completes successfully.
 - Render the building shop bulk purchase button so the "Buy all" option is visible in the card grid UI.
 - Keep the building shop "Buy all" controls above the grid so they are never hidden behind neighbouring cards.

--- a/src/components/PrestigeCard.tsx
+++ b/src/components/PrestigeCard.tsx
@@ -36,17 +36,20 @@ export function PrestigeCard() {
         requirement: formatNumber(prestigeData.minPopulation, { maximumFractionDigits: 0 }),
       });
 
+  const cardTitle = t('prestige.card.title', {
+    name: prestigeName,
+    value: formatNumber(prestigeMult, { maximumFractionDigits: 2 }),
+  });
+
   return (
     <div className="prestige-card">
       <ImageCardButton
         className="prestige-btn"
         icon={prestigeData.icon}
-        title={t('prestige.card.title', {
-          name: prestigeName,
-          value: formatNumber(prestigeMult, { maximumFractionDigits: 2 }),
-        })}
+        title={cardTitle}
         subtitle={subtitle}
         disabled={!canPrestige}
+        ariaLabel={cardTitle}
         onClick={() => {
           if (!canPrestige) return;
           if (

--- a/src/index.css
+++ b/src/index.css
@@ -417,17 +417,28 @@ h1 {
   .prestige-card {
     top: 0.75rem;
     right: 0.75rem;
-    width: calc(100vw - 1.5rem);
+    width: auto;
+    max-width: calc(100vw - 1.5rem);
+    align-items: flex-end;
   }
 
   .prestige-btn {
-    margin: 2px !important;
-    padding: 4px !important;
+    display: inline-flex;
+    width: auto;
+    min-width: 0;
+    margin: 0;
+    padding: 0.35rem 0.5rem;
+    border-radius: 999px;
+    gap: 0;
+  }
+
+  .prestige-btn .card-button__media {
+    width: 2.75rem;
   }
 
   .prestige-btn img {
-    width: 48px;
-    height: 48px;
+    width: 100%;
+    height: auto;
   }
 
   .prestige-btn .card-button__text {
@@ -437,6 +448,7 @@ h1 {
   .prestige-mobile-info {
     display: block;
     margin-top: 0.25rem;
+    text-align: right;
   }
 }
 


### PR DESCRIPTION
## Summary
- adjust the Polta sauna prestige button styling to shrink its footprint on small screens while keeping the card anchored to the top corner
- reuse the prestige card title for the button’s accessible label so the compact mobile layout remains screen-reader friendly
- document the mobile prestige button tweak in the changelog

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cd36c1680c8328857bb23aa168cd22