### PR TITLE
Add SVG icons for new late-game content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Collapsible controls for the building, technology, tier, and Maailma shops.
 - Automate GitHub Pages deployments for the main site and /dev/ preview with combined artifacts.
 - Autogenerate SVG icons for daily tasks based on the shared task data and surface them alongside task details.
+- Generate SVG artwork for late-game buildings and technologies that previously lacked icons.
 
 ### Changed
 - Hide the Maailma shop until Polta Maailma has been used at least once.

--- a/public/assets/buildings/Observatorio.svg
+++ b/public/assets/buildings/Observatorio.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+  <defs>
+    <radialGradient id="sky" cx="0.65" cy="0.3" r="1.1">
+      <stop offset="0%" stop-color="#4c6be5"/>
+      <stop offset="55%" stop-color="#1f2a6b"/>
+      <stop offset="100%" stop-color="#0d1330"/>
+    </radialGradient>
+    <linearGradient id="ground" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#38405c"/>
+      <stop offset="100%" stop-color="#1b1f33"/>
+    </linearGradient>
+    <linearGradient id="dome" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#d7e2ff"/>
+      <stop offset="100%" stop-color="#8da0d8"/>
+    </linearGradient>
+    <linearGradient id="walls" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f2f5ff"/>
+      <stop offset="100%" stop-color="#b0bddb"/>
+    </linearGradient>
+    <linearGradient id="scope" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#5c6f9c"/>
+      <stop offset="100%" stop-color="#b7c7ef"/>
+    </linearGradient>
+  </defs>
+  <rect width="256" height="256" rx="32" fill="url(#sky)"/>
+  <g fill="#fff9c7" opacity="0.9">
+    <circle cx="70" cy="46" r="2.6"/>
+    <circle cx="116" cy="32" r="3"/>
+    <circle cx="168" cy="52" r="2.2"/>
+    <circle cx="204" cy="40" r="1.8"/>
+    <circle cx="184" cy="84" r="2.4"/>
+    <circle cx="134" cy="74" r="1.6"/>
+    <circle cx="92" cy="90" r="1.8"/>
+  </g>
+  <path d="M0 188c36 16 72 24 108 24s72-8 108-24 40-12 40-12v80H0z" fill="url(#ground)" opacity="0.95"/>
+  <g transform="translate(64 92)">
+    <g transform="rotate(-16 124 -20)">
+      <rect x="74" y="-48" width="20" height="104" rx="8" fill="#202b46"/>
+      <rect x="88" y="-32" width="60" height="20" rx="10" fill="url(#scope)" stroke="#2b3558" stroke-width="4"/>
+      <circle cx="142" cy="-22" r="12" fill="#dfe8ff" stroke="#2b3558" stroke-width="4"/>
+      <circle cx="142" cy="-22" r="6" fill="#76c8ff"/>
+    </g>
+    <path d="M128 112h-64l-12 28h88z" fill="#2a3250" opacity="0.85"/>
+    <path d="M32 112h128v48H32z" fill="url(#walls)" stroke="#6577a8" stroke-width="6" stroke-linejoin="round"/>
+    <path d="M36 132h40v28H36zM116 132h40v28h-40z" fill="#e4eafc"/>
+    <path d="M96 42c46 0 76 34 80 72H16c4-38 34-72 80-72z" fill="url(#dome)" stroke="#7489bf" stroke-width="6"/>
+    <path d="M96 32c18 0 34 6 46 18-6 2-10 6-14 12-8-10-18-16-32-16s-24 6-32 16c-4-6-8-10-14-12 12-12 28-18 46-18z" fill="#f7f9ff" opacity="0.75"/>
+    <path d="M56 112V78c0-20 18-36 40-36s40 16 40 36v34" fill="none" stroke="#4c5c8a" stroke-width="6" stroke-linecap="round"/>
+    <path d="M96 70c10 0 18 8 18 18v24H78V88c0-10 8-18 18-18z" fill="#2d3a59" opacity="0.35"/>
+    <circle cx="96" cy="44" r="6" fill="#fff" opacity="0.8"/>
+  </g>
+  <rect width="256" height="256" rx="32" fill="none" stroke="rgba(255,255,255,0.18)" stroke-width="4"/>
+</svg>

--- a/public/assets/buildings/Rantabaari.svg
+++ b/public/assets/buildings/Rantabaari.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#ffb960"/>
+      <stop offset="55%" stop-color="#ff7f6e"/>
+      <stop offset="100%" stop-color="#2643a5"/>
+    </linearGradient>
+    <radialGradient id="sun" cx="0.72" cy="0.3" r="0.32">
+      <stop offset="0%" stop-color="#ffe9a6"/>
+      <stop offset="100%" stop-color="#ff9e4d"/>
+    </radialGradient>
+    <linearGradient id="sand" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f2d48f"/>
+      <stop offset="100%" stop-color="#d9a856"/>
+    </linearGradient>
+    <linearGradient id="drink" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f9f5ff"/>
+      <stop offset="50%" stop-color="#ff5c97"/>
+      <stop offset="100%" stop-color="#ffb347"/>
+    </linearGradient>
+    <linearGradient id="palm" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#1e6136"/>
+      <stop offset="100%" stop-color="#3cb970"/>
+    </linearGradient>
+  </defs>
+  <rect width="256" height="256" rx="32" fill="url(#bg)"/>
+  <circle cx="192" cy="72" r="42" fill="url(#sun)" opacity="0.9"/>
+  <path d="M0 176c32 12 64 18 96 18s64-6 96-18 64-18 64-18v80H0z" fill="url(#sand)" opacity="0.92"/>
+  <g transform="translate(74 58)">
+    <path d="M28 8c5-14 19-26 36-30 18-4 34 1 45 16-14-6-26-5-37 1 8 2 17 7 23 14-13-6-24-6-35-2 11 3 21 10 27 19-15-8-28-9-42-4 9 5 15 13 19 22-18-12-35-16-52-14 9 4 16 11 20 19-17-12-32-15-48-11 11-12 23-18 44-18-7-5-14-8-22-10z"
+          fill="url(#palm)" stroke="#0d3823" stroke-width="3" stroke-linejoin="round"/>
+    <path d="M40 72c-2-16 0-36 7-55" stroke="#0d3823" stroke-width="7" stroke-linecap="round" fill="none"/>
+  </g>
+  <g transform="translate(130 110)">
+    <path d="M32 0H0l18 56-18 38h32l-16-38z" fill="#d9ddea" stroke="#3b3e59" stroke-width="4" stroke-linejoin="round"/>
+    <path d="M4 8h24l-9 28h-6z" fill="url(#drink)"/>
+    <path d="M12 78h8" stroke="#3b3e59" stroke-width="4" stroke-linecap="round"/>
+    <path d="M16-14l30-12" stroke="#ffe9a6" stroke-width="6" stroke-linecap="round"/>
+    <path d="M30-28l14 20" stroke="#f94892" stroke-width="6" stroke-linecap="round"/>
+    <circle cx="46" cy="-14" r="10" fill="#ff6f9f" stroke="#bf2563" stroke-width="3"/>
+  </g>
+  <rect x="0" y="0" width="256" height="256" rx="32" fill="none" stroke="rgba(255,255,255,0.18)" stroke-width="4"/>
+</svg>

--- a/public/assets/buildings/Stadion.svg
+++ b/public/assets/buildings/Stadion.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+  <defs>
+    <linearGradient id="stadiumBg" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#203a65"/>
+      <stop offset="100%" stop-color="#14203d"/>
+    </linearGradient>
+    <linearGradient id="field" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#2ea45a"/>
+      <stop offset="100%" stop-color="#136b35"/>
+    </linearGradient>
+    <linearGradient id="stands" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0%" stop-color="#546d9b"/>
+      <stop offset="100%" stop-color="#7f96c3"/>
+    </linearGradient>
+    <linearGradient id="roof" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#cfd8ee"/>
+      <stop offset="100%" stop-color="#94a5cf"/>
+    </linearGradient>
+    <linearGradient id="lights" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#fdfdfd"/>
+      <stop offset="100%" stop-color="#bbc5e3"/>
+    </linearGradient>
+  </defs>
+  <rect width="256" height="256" rx="32" fill="url(#stadiumBg)"/>
+  <g fill="#1c2746" opacity="0.65">
+    <circle cx="48" cy="48" r="14"/>
+    <circle cx="208" cy="42" r="12"/>
+    <circle cx="226" cy="74" r="8"/>
+    <circle cx="30" cy="84" r="10"/>
+  </g>
+  <g transform="translate(28 68)">
+    <ellipse cx="100" cy="108" rx="100" ry="52" fill="url(#stands)" stroke="#27365a" stroke-width="6"/>
+    <ellipse cx="100" cy="104" rx="74" ry="38" fill="#101c32" opacity="0.65"/>
+    <ellipse cx="100" cy="108" rx="80" ry="40" fill="url(#field)" stroke="#0d4d28" stroke-width="4"/>
+    <ellipse cx="100" cy="108" rx="38" ry="18" fill="none" stroke="#d7f5db" stroke-width="4" stroke-dasharray="16 10"/>
+    <line x1="100" y1="68" x2="100" y2="148" stroke="#d7f5db" stroke-width="4" stroke-dasharray="12 8"/>
+    <ellipse cx="100" cy="108" rx="8" ry="6" fill="#d7f5db"/>
+    <g stroke="#21335c" stroke-width="6" stroke-linecap="round" fill="none">
+      <path d="M-8 72c0-50 40-90 108-90s108 40 108 90"/>
+      <path d="M4 64c0-44 36-78 96-78s96 34 96 78"/>
+    </g>
+    <g fill="url(#roof)" stroke="#4c5e8a" stroke-width="4">
+      <path d="M-12 74c16-60 64-98 124-98s108 38 124 98l-26 16c-16-46-52-74-98-74s-82 28-98 74z"/>
+    </g>
+    <g fill="url(#lights)" stroke="#8d9ec5" stroke-width="3" stroke-linejoin="round">
+      <rect x="-18" y="38" width="16" height="36" rx="4"/>
+      <rect x="186" y="38" width="16" height="36" rx="4"/>
+      <rect x="34" y="20" width="18" height="40" rx="4"/>
+      <rect x="148" y="20" width="18" height="40" rx="4"/>
+    </g>
+    <g fill="#f7f8ff" opacity="0.75">
+      <circle cx="-10" cy="32" r="4"/>
+      <circle cx="194" cy="30" r="4"/>
+      <circle cx="40" cy="12" r="4"/>
+      <circle cx="158" cy="10" r="4"/>
+    </g>
+  </g>
+  <rect width="256" height="256" rx="32" fill="none" stroke="rgba(255,255,255,0.18)" stroke-width="4"/>
+</svg>

--- a/public/assets/tech/Aurinkolasit.svg
+++ b/public/assets/tech/Aurinkolasit.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#ffef8a"/>
+      <stop offset="45%" stop-color="#ffb44d"/>
+      <stop offset="100%" stop-color="#ff6e5d"/>
+    </linearGradient>
+    <linearGradient id="frame" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#2f1f5b"/>
+      <stop offset="100%" stop-color="#563b9c"/>
+    </linearGradient>
+    <linearGradient id="glassL" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#362563"/>
+      <stop offset="100%" stop-color="#15122e"/>
+    </linearGradient>
+    <linearGradient id="glassR" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#2c2454"/>
+      <stop offset="100%" stop-color="#0c1027"/>
+    </linearGradient>
+    <linearGradient id="shine" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#fff2c6" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <rect width="256" height="256" rx="32" fill="url(#bg)"/>
+  <g opacity="0.18">
+    <circle cx="64" cy="56" r="22" fill="#fff"/>
+    <circle cx="188" cy="54" r="18" fill="#fff"/>
+    <path d="M36 192c28 10 52 14 76 14s48-4 76-14c24-8 44-18 68-34-22 36-48 60-80 72-28 10-56 8-88-4-34-12-64-38-88-78 20 18 40 32 64 40z" fill="#fff"/>
+  </g>
+  <g transform="translate(28 86)">
+    <path d="M8 34c16-20 42-34 72-34s56 14 72 34" fill="none" stroke="url(#frame)" stroke-width="16" stroke-linecap="round"/>
+    <path d="M8 34h56c14 0 22 12 24 24l6 32c4 18-8 32-26 32H40c-18 0-32-14-30-32l4-36c1-8 6-18 14-20z" fill="url(#glassL)" stroke="#0f0c2a" stroke-width="6" stroke-linejoin="round"/>
+    <path d="M216 34h-56c-14 0-22 12-24 24l-6 32c-4 18 8 32 26 32h28c18 0 32-14 30-32l-4-36c-1-8-6-18-14-20z" fill="url(#glassR)" stroke="#0f0c2a" stroke-width="6" stroke-linejoin="round"/>
+    <rect x="110" y="40" width="36" height="24" rx="12" fill="url(#frame)" stroke="#0f0c2a" stroke-width="6"/>
+    <path d="M52 34c10-14 30-24 50-24s40 10 50 24" fill="none" stroke="#8b6ae3" stroke-width="6" stroke-linecap="round" opacity="0.4"/>
+    <path d="M30 66l12 36" stroke="#8b6ae3" stroke-width="6" stroke-linecap="round" opacity="0.4"/>
+    <path d="M194 66l-12 36" stroke="#8b6ae3" stroke-width="6" stroke-linecap="round" opacity="0.4"/>
+    <ellipse cx="48" cy="66" rx="34" ry="24" fill="url(#shine)" opacity="0.6"/>
+    <ellipse cx="184" cy="66" rx="34" ry="24" fill="url(#shine)" opacity="0.6"/>
+  </g>
+  <rect width="256" height="256" rx="32" fill="none" stroke="rgba(255,255,255,0.18)" stroke-width="4"/>
+</svg>

--- a/public/assets/tech/Kuumat_Valot.svg
+++ b/public/assets/tech/Kuumat_Valot.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#2c0f4e"/>
+      <stop offset="60%" stop-color="#1d1042"/>
+      <stop offset="100%" stop-color="#0a071e"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0.5" cy="0.2" r="0.7">
+      <stop offset="0%" stop-color="#ff80ff" stop-opacity="0.7"/>
+      <stop offset="100%" stop-color="#ff80ff" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="beamWarm" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#ffd966" stop-opacity="0.85"/>
+      <stop offset="100%" stop-color="#ff872f" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="beamCool" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#8cc8ff" stop-opacity="0.85"/>
+      <stop offset="100%" stop-color="#2565ff" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="housing" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#39446b"/>
+      <stop offset="100%" stop-color="#12192e"/>
+    </linearGradient>
+  </defs>
+  <rect width="256" height="256" rx="32" fill="url(#bg)"/>
+  <circle cx="128" cy="64" r="90" fill="url(#glow)"/>
+  <g transform="translate(22 38)" opacity="0.9">
+    <path d="M48 0h40l12 56-8 8H44l-8-8z" fill="url(#housing)" stroke="#0f1428" stroke-width="6" stroke-linejoin="round"/>
+    <rect x="56" y="16" width="24" height="16" rx="6" fill="#2f3a5a"/>
+    <path d="M64 64l-80 120h120l-24-120z" fill="url(#beamWarm)"/>
+    <circle cx="68" cy="68" r="8" fill="#ffd966"/>
+  </g>
+  <g transform="translate(126 38) scale(-1 1) translate(-126 0)" opacity="0.92">
+    <path d="M48 0h40l12 56-8 8H44l-8-8z" fill="url(#housing)" stroke="#0f1428" stroke-width="6" stroke-linejoin="round"/>
+    <rect x="56" y="16" width="24" height="16" rx="6" fill="#2f3a5a"/>
+    <path d="M64 64l-80 120h120l-24-120z" fill="url(#beamCool)"/>
+    <circle cx="68" cy="68" r="8" fill="#8cc8ff"/>
+  </g>
+  <g fill="#ffb2ff" opacity="0.4">
+    <circle cx="52" cy="210" r="8"/>
+    <circle cx="204" cy="214" r="10"/>
+    <circle cx="136" cy="202" r="6"/>
+    <circle cx="88" cy="198" r="5"/>
+  </g>
+  <rect width="256" height="256" rx="32" fill="none" stroke="rgba(255,255,255,0.18)" stroke-width="4"/>
+</svg>

--- a/public/assets/tech/Kvanttifysiikka.svg
+++ b/public/assets/tech/Kvanttifysiikka.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+  <defs>
+    <radialGradient id="bg" cx="0.5" cy="0.4" r="0.9">
+      <stop offset="0%" stop-color="#1b1f4e"/>
+      <stop offset="60%" stop-color="#101332"/>
+      <stop offset="100%" stop-color="#040514"/>
+    </radialGradient>
+    <radialGradient id="core" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#ff9ff4"/>
+      <stop offset="100%" stop-color="#ff4fa6"/>
+    </radialGradient>
+    <linearGradient id="orbit" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#7ad7ff"/>
+      <stop offset="100%" stop-color="#4f64ff"/>
+    </linearGradient>
+  </defs>
+  <rect width="256" height="256" rx="32" fill="url(#bg)"/>
+  <g fill="#ffffff" opacity="0.12">
+    <circle cx="52" cy="46" r="8"/>
+    <circle cx="210" cy="36" r="6"/>
+    <circle cx="186" cy="92" r="5"/>
+    <circle cx="42" cy="138" r="4"/>
+    <circle cx="220" cy="146" r="7"/>
+    <circle cx="108" cy="218" r="5"/>
+  </g>
+  <g transform="translate(128 128)">
+    <circle r="22" fill="url(#core)"/>
+    <circle r="10" fill="#fff5ff" opacity="0.4"/>
+    <g stroke="url(#orbit)" stroke-width="6" fill="none">
+      <ellipse rx="94" ry="44" transform="rotate(16)" opacity="0.85"/>
+      <ellipse rx="70" ry="108" transform="rotate(-18)" opacity="0.7"/>
+      <ellipse rx="36" ry="120" opacity="0.65"/>
+    </g>
+    <g fill="#7ad7ff" stroke="#ffffff" stroke-width="3">
+      <circle r="9" transform="rotate(16) translate(94 0)"/>
+      <circle r="9" transform="rotate(-18) translate(0 -108)"/>
+      <circle r="9" transform="translate(36 0)"/>
+    </g>
+    <g fill="#ffd966" stroke="#7f4fff" stroke-width="2" opacity="0.75">
+      <circle r="6" transform="rotate(16) translate(-94 0)"/>
+      <circle r="6" transform="rotate(-18) translate(0 108)"/>
+      <circle r="6" transform="translate(-36 0)"/>
+    </g>
+    <circle r="110" fill="none" stroke="rgba(122,215,255,0.1)" stroke-width="10" stroke-dasharray="24 18"/>
+  </g>
+  <rect width="256" height="256" rx="32" fill="none" stroke="rgba(255,255,255,0.18)" stroke-width="4"/>
+</svg>

--- a/src/content/buildings.json
+++ b/src/content/buildings.json
@@ -54,7 +54,7 @@
   {
     "id": "rantabaari",
     "name": "Rantabaari",
-    "icon": "Rantabaari.png",
+    "icon": "Rantabaari.svg",
     "baseCost": 9999999999999999999999999999999999999999999999999999999,
     "costMult": 1.15,
     "baseProd": 10000000000000000000000, 
@@ -63,7 +63,7 @@
   {
     "id": "stadion",
     "name": "Stadion",
-    "icon": "Stadion.png",
+    "icon": "Stadion.svg",
     "baseCost": 99999999999999999999999999999999999999999999999999999990000,
     "costMult": 1.15,
     "baseProd": 52500000000000000000000,
@@ -72,7 +72,7 @@
   {
     "id": "observatorio",
     "name": "Observatorio",
-    "icon": "Observatorio.png",
+    "icon": "Observatorio.svg",
     "baseCost": 999999999999999999999999999999999999999999999999999999900000000,
     "costMult": 1.15,
     "baseProd": 256250000000000000000000,

--- a/src/content/tech.json
+++ b/src/content/tech.json
@@ -76,7 +76,7 @@
   {
     "id": "aurinkolasit",
     "name": "Aurinkolasit",
-    "icon": "Aurinkolasit.png",
+    "icon": "Aurinkolasit.svg",
     "cost": 999999999999999999999999999999999999999999999999999999, 
     "effects": [{ "type": "mult", "target": "population_cps", "value": 5.4 }],
     "limit": 1,
@@ -85,7 +85,7 @@
   {
     "id": "kuumat_valot",
     "name": "Kuumat Valot",
-    "icon": "Kuumat_Valot.png",
+    "icon": "Kuumat_Valot.svg",
     "cost": 999999999999999999999999999999999999999999999999999999000, 
     "effects": [{ "type": "mult", "target": "population_cps", "value": 5.8 }],
     "limit": 1,
@@ -94,7 +94,7 @@
   {
     "id": "kvanttifysiikka",
     "name": "Kvanttifysiikka",
-    "icon": "Kvanttifysiikka.png",
+    "icon": "Kvanttifysiikka.svg",
     "cost": 999999999999999999999999999999999999999999999999999999000000, 
     "effects": [{ "type": "mult", "target": "population_cps", "value": 6.0 }],
     "limit": 1,


### PR DESCRIPTION
## Summary
- generate vector icons for the late-game buildings that were missing artwork and point their definitions at the new assets
- add SVG art for the latest technologies so their cards no longer reference non-existent PNGs
- document the new vector assets in the changelog

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d12aa5c22c8328b2ddc1c67251bea3