### PR TITLE
Format scientific notation with two decimal places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Move the daily tasks list into a collapsible drawer beneath the settings menu and highlight ready-to-claim tasks.
 - Show the reward each daily task grants and apply active bonuses to the LPS counter in the HUD.
 - Display large numeric values in scientific notation once they exceed 1e9 to improve readability in the UI.
+- Format scientific notation with two decimal places for consistent precision.
 - Surface a contextual "Buy all" summary and tooltips in the store for clearer bulk purchases.
 - Update the Finnish daily tasks expired bonus label to read "Bonus käytetty".
 

--- a/src/i18n/useLocale.test.tsx
+++ b/src/i18n/useLocale.test.tsx
@@ -20,21 +20,27 @@ describe('useLocale.formatNumber', () => {
     await setTestLanguage('en');
   });
 
-  it('uses scientific notation when the number exceeds the threshold', () => {
+  it('uses scientific notation with two decimal places when the number exceeds the threshold', () => {
+    renderWithI18n(<FormatNumberDisplay value={1_000_000_000} />);
+
+    expect(screen.getByTestId('formatted-value')).toHaveTextContent('1.00E9');
+  });
+
+  it('enforces two decimal places for scientific notation even when options request fewer digits', () => {
     renderWithI18n(
-      <FormatNumberDisplay value={1_000_000_000} options={{ maximumFractionDigits: 0 }} />,
+      <FormatNumberDisplay
+        value={1_000_000_000}
+        options={{ maximumFractionDigits: 0 }}
+        testId="custom-options"
+      />,
     );
 
-    expect(screen.getByTestId('formatted-value')).toHaveTextContent('1E9');
+    expect(screen.getByTestId('custom-options')).toHaveTextContent('1.00E9');
   });
 
   it('formats large bigint values with scientific notation', () => {
     renderWithI18n(
-      <FormatNumberDisplay
-        value={123_456_789_012_345_678_901_234_567_890n}
-        options={{ maximumFractionDigits: 2 }}
-        testId="bigint-value"
-      />,
+      <FormatNumberDisplay value={123_456_789_012_345_678_901_234_567_890n} testId="bigint-value" />,
     );
 
     expect(screen.getByTestId('bigint-value')).toHaveTextContent('1.23E29');

--- a/src/i18n/useLocale.ts
+++ b/src/i18n/useLocale.ts
@@ -55,9 +55,21 @@ export function useLocale() {
     (value: number | bigint, options?: FormatNumberOptions) => {
       const locale = i18n.language || resolvedLang;
       const targetValue = typeof value === 'bigint' ? value : Number(value);
-      const formatOptions: FormatNumberOptions | undefined = shouldUseScientificNotation(targetValue)
-        ? { ...(options ?? {}), notation: 'scientific' }
-        : options;
+      let formatOptions: FormatNumberOptions | undefined = options;
+
+      if (shouldUseScientificNotation(targetValue)) {
+        const restOptions = { ...(options ?? {}) };
+        delete restOptions.minimumSignificantDigits;
+        delete restOptions.maximumSignificantDigits;
+
+        formatOptions = {
+          ...restOptions,
+          notation: 'scientific',
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2,
+        };
+      }
+
       const formatter = new Intl.NumberFormat(locale, formatOptions);
       return formatter.format(targetValue);
     },


### PR DESCRIPTION
## Summary
- force scientific notation formatting to always emit two decimal places and remove conflicting significant-digit options
- update locale formatting tests to cover the enforced precision
- document the scientific-notation precision change in the changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d18969f1f08328b8fc57e9261af88b