### PR TITLE
Add in-app refresh prompt when new build is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Development-only environment flag that multiplies population-per-second by `tier * 100` to speed up local testing.
 - Add a procedurally generated splash animation and sound when throwing löyly.
 - Surface an interactive CPS multiplier tooltip beside the HUD counter with a detailed breakdown of active bonuses.
+- Prompt players to refresh when a newer build becomes available after they interact with the game.
 
 ### Changed
 - Hide the Maailma shop until Polta Maailma has been used at least once.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { MaailmaShop } from './ui/MaailmaShop';
 import { PoltaMaailmaButton } from './ui/PoltaMaailmaButton';
 import { DailyTasksPanel } from './ui/dailyTasksUI';
 import { useLocale } from './i18n/useLocale';
+import { UpdateNotification } from './components/UpdateNotification';
 
 function App() {
   const { t } = useLocale();
@@ -60,6 +61,7 @@ function App() {
         </div>
       )}
       <Settings />
+      <UpdateNotification />
       <HUD />
       <DailyTasksPanel />
       <PrestigeCard />

--- a/src/app/versioning.ts
+++ b/src/app/versioning.ts
@@ -1,0 +1,53 @@
+export interface AppVersionMetadata {
+  version?: unknown
+  buildTime?: unknown
+}
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0
+
+export const CURRENT_APP_VERSION =
+  typeof __APP_VERSION__ === 'string' ? __APP_VERSION__ : ''
+
+export const CURRENT_APP_BUILD_TIME =
+  typeof __APP_BUILD_TIME__ === 'string' ? __APP_BUILD_TIME__ : ''
+
+export const isUpdateAvailable = (
+  metadata: AppVersionMetadata | null | undefined,
+  currentVersion: string = CURRENT_APP_VERSION,
+  currentBuildTime: string = CURRENT_APP_BUILD_TIME,
+): boolean => {
+  if (!metadata) return false
+
+  const remoteVersion = isNonEmptyString(metadata.version) ? metadata.version : ''
+  const remoteBuildTime = isNonEmptyString(metadata.buildTime) ? metadata.buildTime : ''
+  const localVersion = isNonEmptyString(currentVersion) ? currentVersion : ''
+  const localBuildTime = isNonEmptyString(currentBuildTime) ? currentBuildTime : ''
+
+  const hasVersionMismatch =
+    remoteVersion.length > 0 && localVersion.length > 0 && remoteVersion !== localVersion
+
+  if (hasVersionMismatch) return true
+
+  const hasBuildTimeMismatch =
+    remoteBuildTime.length > 0 && localBuildTime.length > 0 && remoteBuildTime !== localBuildTime
+
+  return hasBuildTimeMismatch
+}
+
+export const buildVersionCheckUrl = () => {
+  const baseUrl = import.meta.env.BASE_URL ?? '/'
+  const normalizedBase = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`
+  if (/^[a-z]+:\/\//i.test(normalizedBase)) {
+    const protocolEnd = normalizedBase.indexOf('://') + 3
+    const pathStart = normalizedBase.indexOf('/', protocolEnd)
+    const rawPath = pathStart >= 0 ? normalizedBase.slice(pathStart) : '/'
+    const cleanPath = rawPath.split(/[?#]/)[0] || '/'
+    const ensured = cleanPath.endsWith('/') ? cleanPath : `${cleanPath}/`
+    return `${ensured}app-version.json`
+  }
+  if (normalizedBase.startsWith('/')) {
+    return `${normalizedBase}app-version.json`
+  }
+  return `/${normalizedBase}app-version.json`
+}

--- a/src/components/UpdateNotification.tsx
+++ b/src/components/UpdateNotification.tsx
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useLocale } from '../i18n/useLocale'
+import {
+  buildVersionCheckUrl,
+  isUpdateAvailable,
+  type AppVersionMetadata,
+} from '../app/versioning'
+
+const CHECK_COOLDOWN_MS = 30_000
+
+const fetchLatestVersion = async (): Promise<AppVersionMetadata | null> => {
+  if (typeof fetch !== 'function') {
+    console.warn('Global fetch is unavailable; skipping version check')
+    return null
+  }
+  try {
+    const response = await fetch(`${buildVersionCheckUrl()}?ts=${Date.now()}`, {
+      cache: 'no-store',
+    })
+    if (!response.ok) {
+      console.warn('Version check failed with status', response.status)
+      return null
+    }
+    const payload = (await response.json()) as unknown
+    if (!payload || typeof payload !== 'object') {
+      console.warn('Version metadata response was not an object')
+      return null
+    }
+    return payload as AppVersionMetadata
+  } catch (error) {
+    console.warn('Failed to fetch version metadata', error)
+    return null
+  }
+}
+
+export function UpdateNotification() {
+  const { t } = useLocale()
+  const [updateReady, setUpdateReady] = useState(false)
+  const lastCheckRef = useRef(-Infinity)
+  const checkInFlightRef = useRef<Promise<void> | null>(null)
+
+  const checkForUpdate = useCallback(async () => {
+    if (updateReady) return
+    if (checkInFlightRef.current) return
+
+    const now = Date.now()
+    if (now - lastCheckRef.current < CHECK_COOLDOWN_MS) {
+      return
+    }
+
+    const request = (async () => {
+      const metadata = await fetchLatestVersion()
+      if (metadata && isUpdateAvailable(metadata)) {
+        setUpdateReady(true)
+      }
+      lastCheckRef.current = Date.now()
+    })()
+
+    checkInFlightRef.current = request
+
+    try {
+      await request
+    } finally {
+      checkInFlightRef.current = null
+    }
+  }, [updateReady])
+
+  useEffect(() => {
+    if (updateReady) return
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      return
+    }
+    const handleInteraction = () => {
+      void checkForUpdate()
+    }
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        void checkForUpdate()
+      }
+    }
+
+    window.addEventListener('pointerdown', handleInteraction)
+    window.addEventListener('keydown', handleInteraction)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+
+    return () => {
+      window.removeEventListener('pointerdown', handleInteraction)
+      window.removeEventListener('keydown', handleInteraction)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
+  }, [checkForUpdate, updateReady])
+
+  const handleRefresh = useCallback(() => {
+    try {
+      window.location.reload()
+    } catch (error) {
+      console.error('Failed to reload the page', error)
+    }
+  }, [])
+
+  if (!updateReady) {
+    return null
+  }
+
+  return (
+    <div className="update-notification" role="status" aria-live="polite">
+      <div className="update-notification__content">
+        <span className="update-notification__title">{t('app.updateAvailable.title')}</span>
+        <span className="update-notification__description">
+          {t('app.updateAvailable.message')}
+        </span>
+      </div>
+      <button
+        type="button"
+        className="btn btn--primary update-notification__action"
+        onClick={handleRefresh}
+      >
+        {t('app.updateAvailable.refresh')}
+      </button>
+    </div>
+  )
+}

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1,6 +1,9 @@
 {
   "app.title": "Suomidle",
   "app.tapToStart": "Tap to start",
+  "app.updateAvailable.title": "Update available",
+  "app.updateAvailable.message": "A newer version of the game is ready.",
+  "app.updateAvailable.refresh": "Refresh now",
   "nav.home": "Home",
   "nav.shop": "Shop",
   "nav.tech": "Technologies",

--- a/src/i18n/locales/fi/common.json
+++ b/src/i18n/locales/fi/common.json
@@ -1,6 +1,9 @@
 {
   "app.title": "Suomidle",
   "app.tapToStart": "Napauta aloittaaksesi",
+  "app.updateAvailable.title": "Päivitys saatavilla",
+  "app.updateAvailable.message": "Peliin on saatavilla uudempi versio.",
+  "app.updateAvailable.refresh": "Päivitä sivu",
   "nav.home": "Koti",
   "nav.shop": "Kauppa",
   "nav.tech": "Teknologiat",

--- a/src/i18n/locales/sv/common.json
+++ b/src/i18n/locales/sv/common.json
@@ -1,6 +1,9 @@
 {
   "app.title": "Suomidle",
   "app.tapToStart": "Tryck för att starta",
+  "app.updateAvailable.title": "Uppdatering tillgänglig",
+  "app.updateAvailable.message": "En nyare version av spelet finns tillgänglig.",
+  "app.updateAvailable.refresh": "Uppdatera sidan",
   "nav.home": "Hem",
   "nav.shop": "Butik",
   "nav.tech": "Tekniker",

--- a/src/index.css
+++ b/src/index.css
@@ -961,3 +961,55 @@ h1 {
     width: 100%;
   }
 }
+
+.update-notification {
+  position: fixed;
+  inset-inline: 0;
+  bottom: 1.5rem;
+  margin-inline: auto;
+  width: min(90vw, 32rem);
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-radius: 1rem;
+  border: 1px solid color-mix(in srgb, var(--color-text) 18%, transparent);
+  background: color-mix(in srgb, var(--surface-elevated) 92%, transparent);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.5);
+  color: var(--color-text);
+  z-index: 1200;
+}
+
+.update-notification__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  text-align: start;
+}
+
+.update-notification__title {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.update-notification__description {
+  font-size: 0.9rem;
+  color: color-mix(in srgb, var(--color-text) 85%, transparent);
+}
+
+.update-notification__action {
+  white-space: nowrap;
+}
+
+@media (max-width: 600px) {
+  .update-notification {
+    flex-direction: column;
+    align-items: stretch;
+    text-align: start;
+  }
+
+  .update-notification__action {
+    width: 100%;
+  }
+}

--- a/src/tests/versioning.test.ts
+++ b/src/tests/versioning.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { isUpdateAvailable } from '../app/versioning'
+
+describe('isUpdateAvailable', () => {
+  it('returns false when metadata is null', () => {
+    expect(isUpdateAvailable(null, '1.0.0', '2024-01-01T00:00:00.000Z')).toBe(false)
+  })
+
+  it('returns false when versions and build times match', () => {
+    expect(
+      isUpdateAvailable(
+        { version: '1.0.0', buildTime: '2024-01-01T00:00:00.000Z' },
+        '1.0.0',
+        '2024-01-01T00:00:00.000Z',
+      ),
+    ).toBe(false)
+  })
+
+  it('returns true when versions differ', () => {
+    expect(
+      isUpdateAvailable(
+        { version: '1.0.1', buildTime: '2024-01-02T00:00:00.000Z' },
+        '1.0.0',
+        '2024-01-01T00:00:00.000Z',
+      ),
+    ).toBe(true)
+  })
+
+  it('returns true when build time differs and version is unknown', () => {
+    expect(
+      isUpdateAvailable(
+        { buildTime: '2024-01-02T00:00:00.000Z' },
+        '',
+        '2024-01-01T00:00:00.000Z',
+      ),
+    ).toBe(true)
+  })
+
+  it('returns false when metadata lacks identifiers', () => {
+    expect(isUpdateAvailable({}, '', '')).toBe(false)
+  })
+})

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,4 @@
 /// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string
+declare const __APP_BUILD_TIME__: string

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
@@ -8,9 +8,73 @@ declare const process: { env?: Record<string, string | undefined> }
 const envBase = process?.env?.VITE_BASE ?? process?.env?.BASE_URL ?? '/'
 const base = envBase.endsWith('/') ? envBase : `${envBase}/`
 
+const commitSha =
+  process?.env?.VERCEL_GIT_COMMIT_SHA ??
+  process?.env?.GITHUB_SHA ??
+  process?.env?.COMMIT_SHA ??
+  process?.env?.GIT_COMMIT ??
+  process?.env?.CI_COMMIT_SHA ??
+  process?.env?.BUILD_SOURCEVERSION
+
+const packageVersion = process?.env?.npm_package_version
+
+const appVersion = commitSha ?? packageVersion ?? 'dev'
+const buildTime = new Date().toISOString()
+
+const versionAssetName = 'app-version.json'
+const versionPayload = JSON.stringify({ version: appVersion, buildTime })
+
+const normalizeBasePath = (value: string) => {
+  if (/^[a-z]+:\/\//i.test(value)) {
+    const protocolEnd = value.indexOf('://') + 3
+    const pathStart = value.indexOf('/', protocolEnd)
+    const rawPath = pathStart >= 0 ? value.slice(pathStart) : '/'
+    const cleanPath = rawPath.split(/[?#]/)[0] || '/'
+    return cleanPath.endsWith('/') ? cleanPath : `${cleanPath}/`
+  }
+  const withTrailingSlash = value.endsWith('/') ? value : `${value}/`
+  return withTrailingSlash.startsWith('/') ? withTrailingSlash : `/${withTrailingSlash}`
+}
+
+const basePathForRequests = normalizeBasePath(base)
+
+const versionPaths = new Set<string>([
+  `/${versionAssetName}`,
+  `${basePathForRequests}${versionAssetName}`,
+])
+
+const versionPlugin: Plugin = {
+  name: 'suomidle-app-version',
+  configureServer(server) {
+    server.middlewares.use((req, res, next) => {
+      const rawUrl = (req as { url?: string }).url ?? ''
+      const requestPath = rawUrl.split('?')[0]
+      if (!requestPath || !versionPaths.has(requestPath)) {
+        next()
+        return
+      }
+
+      res.setHeader('Content-Type', 'application/json')
+      res.setHeader('Cache-Control', 'no-store')
+      res.end(versionPayload)
+    })
+  },
+  generateBundle() {
+    this.emitFile({
+      type: 'asset',
+      fileName: versionAssetName,
+      source: `${versionPayload}\n`,
+    })
+  },
+}
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), versionPlugin],
   base,
+  define: {
+    __APP_VERSION__: JSON.stringify(appVersion),
+    __APP_BUILD_TIME__: JSON.stringify(buildTime),
+  },
   // @ts-expect-error - Vitest config
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- emit build metadata via Vite to expose an app-version endpoint and globals
- add version helpers plus an on-screen update banner with refresh CTA and styling
- localize the prompt copy across languages and cover the detection logic with tests

## Testing
- npm run lint
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2830659448328aa8330ede578e25f