### PR TITLE
Adjust Tuhka gain scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Prompt players to refresh when a newer build becomes available after they interact with the game.
 
 ### Changed
+- Update the Tuhka gain formula to use a higher prestige scaling base and grant additional bonuses past tier 10.
 - Hide the Maailma shop until Polta Maailma has been used at least once.
 - Update the page title to display "suomidle" in browser tabs.
 - Namespace persisted local storage keys by environment to isolate saves across deployments.

--- a/src/data/maailma_shop.json
+++ b/src/data/maailma_shop.json
@@ -3,7 +3,7 @@
     "id": "tuhka",
     "name_fi": "Tuhka",
     "short_fi": "Tuhka",
-    "accrual_formula_fi": "Tuhka = floor( sqrt(taso * log10(kertoja + 1)) )",
+    "accrual_formula_fi": "Tuhka = floor( 3.2 * sqrt(log10(kertoja + 1)) * (1 + 0.25 * max(0, taso - 10)) )",
     "spend_behaviour": "persistent",
     "icon": "Tuhka.png"
   },

--- a/src/systems/__tests__/maailma.test.ts
+++ b/src/systems/__tests__/maailma.test.ts
@@ -69,7 +69,7 @@ afterEach(() => {
 });
 
 describe('maailma system', () => {
-  it('uses log-tier formula for tuhka awards', () => {
+  it('uses logarithmic prestige scaling and tier bonuses for tuhka awards', () => {
     const state = createGameState({
       tierLevel: 13,
       prestigeMult: Number(1.2e24),
@@ -77,7 +77,7 @@ describe('maailma system', () => {
 
     const preview = getTuhkaAwardPreview(state);
 
-    expect(preview.toNumber()).toBe(17);
+    expect(preview.toNumber()).toBe(27);
     expect(canPoltaMaailma(state)).toBe(true);
   });
 

--- a/src/systems/maailma.ts
+++ b/src/systems/maailma.ts
@@ -193,10 +193,19 @@ export const getTuhkaAwardPreview = (state: GameState): Decimal => {
   const logTerm = Decimal.log10(multiplier.plus(1));
   if (!logTerm.isFinite() || logTerm.lte(0)) return zero;
 
-  const product = tier.mul(logTerm);
-  if (!product.isFinite() || product.lte(0)) return zero;
+  const sqrtLogTerm = logTerm.sqrt();
+  if (!sqrtLogTerm.isFinite() || sqrtLogTerm.lte(0)) return zero;
 
-  return product.sqrt().floor();
+  const baseAward = sqrtLogTerm.mul(3.2);
+  if (!baseAward.isFinite() || baseAward.lte(0)) return zero;
+
+  const tierBonusMultiplier = Decimal.max(tier.minus(10), zero).mul(0.25).plus(1);
+  if (!tierBonusMultiplier.isFinite() || tierBonusMultiplier.lte(0)) return zero;
+
+  const scaledAward = baseAward.mul(tierBonusMultiplier);
+  if (!scaledAward.isFinite() || scaledAward.lte(0)) return zero;
+
+  return scaledAward.floor();
 };
 
 export const canPoltaMaailma = (state: GameState): boolean =>


### PR DESCRIPTION
## Summary
- update the Tuhka award calculation to use a 3.2 * sqrt(log10(kertoja + 1)) base and tier bonus multiplier
- align the Maailma shop formula copy and unit tests with the new scaling
- record the updated Ash gain formula in the changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2e0702c60832897f33d1787a26cab