### PR TITLE
Align Tuhka previews with shared helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 
 ### Fixed
+- Align the Tuhka preview and awards with the Maailma system helper so UI projections match granted ash.
 - Ensure the "Löyly streak 60 s" daily task registers completions when players stay within the 2 s gap limit.
 - Prevent GitHub Pages deployments from failing when promoting the root build into the combined artifact.
 - Remove decimals from the Lämpötila counter for clearer progress tracking.

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -18,6 +18,7 @@ import {
 } from './buildingPurchase';
 import maailmaShop from '../data/maailma_shop.json' assert { type: 'json' };
 import { computeCpsBase, computeTierBonusMultiplier, computeTotalBuildingCount } from './cpsUtils';
+import { computeTuhkaAward } from '../systems/maailma';
 import {
   createInitialDailyTasksState,
   syncDailyTasksState,
@@ -178,8 +179,6 @@ const STORAGE_NAMESPACE = resolveStorageNamespace();
 export const STORAGE_KEY = STORAGE_NAMESPACE
   ? `${STORAGE_KEY_BASE}:${STORAGE_NAMESPACE}`
   : STORAGE_KEY_BASE;
-const decimalZero = new Decimal(0);
-
 type RawMaailmaShopEffect = {
   type?: unknown;
   value?: unknown;
@@ -1265,23 +1264,7 @@ export const getTuhkaAwardPreview = (): TuhkaAwardPreview => {
   const state = useGameStore.getState();
   const current = toBigInt(state.maailma.tuhka);
   const totalEarned = toBigInt(state.maailma.totalTuhkaEarned);
-  const rawTier = new Decimal(state.tierLevel ?? 0);
-  const tier = rawTier.isFinite() ? Decimal.max(rawTier, decimalZero) : decimalZero;
-  const rawMultiplier = new Decimal(state.prestigeMult ?? 0);
-  const multiplier = rawMultiplier.isFinite()
-    ? Decimal.max(rawMultiplier, decimalZero)
-    : decimalZero;
-
-  let awardDecimal = decimalZero;
-  if (tier.gt(0)) {
-    const logTerm = Decimal.log10(multiplier.plus(1));
-    if (logTerm.isFinite() && logTerm.gt(0)) {
-      const product = tier.mul(logTerm);
-      if (product.isFinite() && product.gt(0)) {
-        awardDecimal = product.sqrt().floor();
-      }
-    }
-  }
+  const awardDecimal = computeTuhkaAward(state.tierLevel ?? 0, state.prestigeMult ?? 0);
 
   const award =
     awardDecimal.isFinite() && awardDecimal.gte(0)

--- a/src/ui/PoltaMaailmaButton.test.tsx
+++ b/src/ui/PoltaMaailmaButton.test.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom';
 import { screen } from '@testing-library/react';
 
 import { PoltaMaailmaButton } from './PoltaMaailmaButton';
-import { useGameStore } from '../app/store';
+import { getTuhkaAwardPreview, useGameStore } from '../app/store';
 import { renderWithI18n, setTestLanguage } from '../tests/testUtils';
 import i18n from '../i18n';
 
@@ -14,7 +14,7 @@ describe('PoltaMaailmaButton', () => {
     useGameStore.setState((state) => ({
       ...state,
       tierLevel: 1,
-      prestigeMult: 1,
+      prestigeMult: 0,
       maailma: {
         ...state.maailma,
         tuhka: '0',
@@ -29,5 +29,36 @@ describe('PoltaMaailmaButton', () => {
     const button = screen.getByRole('button', { name: i18n.t('maailma.action') });
     expect(button).toBeDisabled();
     expect(button).toHaveAttribute('title', i18n.t('maailma.tooltip.noAsh'));
+  });
+
+  it('uses the documented Tuhka formula for high-tier previews', () => {
+    const tierLevel = 15;
+    const prestigeMult = 999;
+    const currentTuhka = 123n;
+    const totalEarned = 456n;
+
+    useGameStore.setState((state) => ({
+      ...state,
+      tierLevel,
+      prestigeMult,
+      maailma: {
+        ...state.maailma,
+        tuhka: currentTuhka.toString(),
+        totalTuhkaEarned: totalEarned.toString(),
+      },
+    }));
+
+    const preview = getTuhkaAwardPreview();
+
+    const tierBonus = Math.max(tierLevel - 10, 0) * 0.25 + 1;
+    const expectedAwardNumber = Math.floor(
+      Math.sqrt(Math.log10(prestigeMult + 1)) * 3.2 * tierBonus,
+    );
+    const expectedAward = BigInt(expectedAwardNumber);
+
+    expect(expectedAwardNumber).toBeGreaterThan(0);
+    expect(preview.award).toBe(expectedAward);
+    expect(preview.availableAfter).toBe(currentTuhka + expectedAward);
+    expect(preview.totalEarnedAfter).toBe(totalEarned + expectedAward);
   });
 });


### PR DESCRIPTION
## Summary
- extract the Tuhka award computation into a shared helper and reuse it for the Maailma system preview
- update the store preview/polta flow to call the helper so awarded ash matches the JSON formula
- add a high-tier regression test for the preview and document the fix in the changelog

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d2ebde323c832893def4f7aea46832