### PR TITLE
Remove unused Decimal import from store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 
 ### Fixed
+- Remove an unused Decimal.js import from the store to restore successful TypeScript builds.
 - Align the Tuhka preview and awards with the Maailma system helper so UI projections match granted ash.
 - Ensure the "Löyly streak 60 s" daily task registers completions when players stay within the 2 s gap limit.
 - Prevent GitHub Pages deployments from failing when promoting the root build into the combined artifact.

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,4 +1,3 @@
-import Decimal from 'decimal.js';
 import { create } from 'zustand';
 import {
   persist,


### PR DESCRIPTION
## Summary
- remove the unused `decimal.js` import from the store so the TypeScript build no longer fails the no-unused-vars check
- document the build fix in the changelog under the unreleased notes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2eedbf75883288316d1984c50e8fb