### PR TITLE
Fix Tuhka awards ignoring prestige baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 
 ### Fixed
+- Clamp the prestige multiplier baseline in the Tuhka formula so fresh profiles no longer receive a free ash award.
 - Remove an unused Decimal.js import from the store to restore successful TypeScript builds.
 - Align the Tuhka preview and awards with the Maailma system helper so UI projections match granted ash.
 - Ensure the "Löyly streak 60 s" daily task registers completions when players stay within the 2 s gap limit.

--- a/src/systems/__tests__/maailma.test.ts
+++ b/src/systems/__tests__/maailma.test.ts
@@ -81,6 +81,15 @@ describe('maailma system', () => {
     expect(canPoltaMaailma(state)).toBe(true);
   });
 
+  it('returns zero tuhka when the prestige multiplier is at the baseline', () => {
+    const state = createGameState();
+
+    const preview = getTuhkaAwardPreview(state);
+
+    expect(preview.toNumber()).toBe(0);
+    expect(canPoltaMaailma(state)).toBe(false);
+  });
+
   it('resets progress while preserving maailma state', () => {
     const state = createGameState({
       population: 987654,

--- a/src/systems/maailma.ts
+++ b/src/systems/maailma.ts
@@ -73,9 +73,10 @@ export const computeTuhkaAward = (
   const tier = rawTier.isFinite() ? Decimal.max(rawTier, zero) : zero;
   const rawMultiplier = decimalFrom(prestigeMultiplier ?? 0);
   const multiplier = rawMultiplier.isFinite() ? Decimal.max(rawMultiplier, zero) : zero;
+  const bonusMultiplier = Decimal.max(multiplier.minus(1), zero);
   if (tier.lte(0)) return zero;
 
-  const logTerm = Decimal.log10(multiplier.plus(1));
+  const logTerm = Decimal.log10(bonusMultiplier.plus(1));
   if (!logTerm.isFinite() || logTerm.lte(0)) return zero;
 
   const sqrtLogTerm = logTerm.sqrt();

--- a/src/tests/gameStoreMaailma.test.ts
+++ b/src/tests/gameStoreMaailma.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { useGameStore, MAAILMA_BUFF_REWARD_PREFIX } from '../app/store';
+import { useGameStore, MAAILMA_BUFF_REWARD_PREFIX, getTuhkaAwardPreview } from '../app/store';
 import { applyPermanentBonuses } from '../effects/applyPermanentBonuses';
 import { createInitialDailyTasksState, getTemperatureGainMultiplier } from '../systems/dailyTasks';
 
@@ -41,6 +41,25 @@ const resetStoreState = () => {
 describe('Maailma upgrades via store actions', () => {
   beforeEach(() => {
     resetStoreState();
+  });
+
+  it('shows zero tuhka award when prestige multiplier is at baseline', () => {
+    useGameStore.setState((state) => ({
+      ...state,
+      tierLevel: 1,
+      prestigeMult: 1,
+      maailma: {
+        ...state.maailma,
+        tuhka: '0',
+        totalTuhkaEarned: '0',
+      },
+    }));
+
+    const preview = getTuhkaAwardPreview();
+
+    expect(preview.award).toBe(0n);
+    expect(preview.availableAfter).toBe(preview.current);
+    expect(preview.totalEarnedAfter).toBe(preview.totalEarned);
   });
 
   it('updates cps and permanent modifiers immediately after purchases', () => {

--- a/src/ui/PoltaMaailmaButton.test.tsx
+++ b/src/ui/PoltaMaailmaButton.test.tsx
@@ -51,8 +51,9 @@ describe('PoltaMaailmaButton', () => {
     const preview = getTuhkaAwardPreview();
 
     const tierBonus = Math.max(tierLevel - 10, 0) * 0.25 + 1;
+    const prestigeBonus = Math.max(prestigeMult - 1, 0);
     const expectedAwardNumber = Math.floor(
-      Math.sqrt(Math.log10(prestigeMult + 1)) * 3.2 * tierBonus,
+      Math.sqrt(Math.log10(prestigeBonus + 1)) * 3.2 * tierBonus,
     );
     const expectedAward = BigInt(expectedAwardNumber);
 


### PR DESCRIPTION
## Summary
- clamp the sauna prestige multiplier to its bonus portion before computing Tuhka awards
- document the regression fix in the changelog and align UI/store tests with the corrected formula
- add regression coverage so both system and store previews return zero ash at the baseline multiplier

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2e9573eac832891eac375bca62fd4