### PR TITLE
Remove Maailmankivi upgrade and refund Tuhka

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Surface a contextual "Buy all" summary and tooltips in the store for clearer bulk purchases.
 - Update the Finnish daily tasks expired bonus label to read "Bonus käytetty".
 - Align Maailma shop balance values, translations, and tests with the latest Ash data.
+- Remove the "Maailmankivi" Maailma upgrade and refund its cost to existing saves.
 
 
 ### Fixed

--- a/src/data/maailma_shop.json
+++ b/src/data/maailma_shop.json
@@ -71,18 +71,6 @@
       "cost_tuhka": [35]
     },
     {
-      "id": "maailmankivi",
-      "name_fi": "Maailmankivi",
-      "icon": "Maailmankivi.png",
-      "description_fi": "Avaa seuraava taso yhden tason aiemmin (–1 tier unlock).",
-      "effect": {
-        "type": "tier_unlock_offset",
-        "value": -1
-      },
-      "max_level": 1,
-      "cost_tuhka": [60]
-    },
-    {
       "id": "tyhjyys_tehokkuus",
       "name_fi": "Tyhjyyden tehokkuus",
       "icon": "Tyhjyys_tehokkuus.png",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -187,8 +187,6 @@
   "maailma.upgrades.ikuiset_hiillokset.description": "All buildings' base production ×1.50 per level (multiplicative).",
   "maailma.upgrades.feeniks_sauna.name": "Phoenix Sauna",
   "maailma.upgrades.feeniks_sauna.description": "Each Burn Sauna starts with at least ×10 base multiplier.",
-  "maailma.upgrades.maailmankivi.name": "Worldstone",
-  "maailma.upgrades.maailmankivi.description": "Unlock the next tier one level earlier (−1 tier unlock).",
   "maailma.upgrades.tyhjyys_tehokkuus.name": "Void Efficiency",
   "maailma.upgrades.tyhjyys_tehokkuus.description": "Reduces building cost multiplier by 0.01 per level (e.g. 1.15 → 1.14).",
   "maailma.upgrades.kosminen_karsivallisyys.name": "Cosmic Patience",

--- a/src/i18n/locales/fi/common.json
+++ b/src/i18n/locales/fi/common.json
@@ -187,8 +187,6 @@
   "maailma.upgrades.rakennuksen_siunaus.description": "Saat +0.1% globaalin kertoimen jokaisesta omistamastasi rakennuksesta.",
   "maailma.upgrades.feeniks_sauna.name": "Feeniks-sauna",
   "maailma.upgrades.feeniks_sauna.description": "Jokainen Polta sauna alkaa vähintään ×10 peruskertoimella.",
-  "maailma.upgrades.maailmankivi.name": "Maailmankivi",
-  "maailma.upgrades.maailmankivi.description": "Avaa seuraava taso yhden tason aiemmin (–1 tier unlock).",
   "maailma.upgrades.tyhjyys_tehokkuus.name": "Tyhjyyden tehokkuus",
   "maailma.upgrades.tyhjyys_tehokkuus.description": "Rakennusten kustannuskertoimen alennus –0.01 per taso (esim. 1.15 → 1.14).",
   "maailma.upgrades.kosminen_karsivallisyys.name": "Kosminen kärsivällisyys",

--- a/src/i18n/locales/sv/common.json
+++ b/src/i18n/locales/sv/common.json
@@ -187,8 +187,6 @@
   "maailma.upgrades.rakennuksen_siunaus.description": "Få +0,1 % global multiplikator för varje byggnad du äger.",
   "maailma.upgrades.feeniks_sauna.name": "Fenixbastu",
   "maailma.upgrades.feeniks_sauna.description": "Varje Bränn bastun startar med minst ×10 baskoefficient.",
-  "maailma.upgrades.maailmankivi.name": "Världsstenen",
-  "maailma.upgrades.maailmankivi.description": "Lås upp nästa nivå ett steg tidigare (−1 nivåkrav).",
   "maailma.upgrades.tyhjyys_tehokkuus.name": "Tomhetseffektivitet",
   "maailma.upgrades.tyhjyys_tehokkuus.description": "Minskar byggnadskostnadsfaktorn med 0,01 per nivå (t.ex. 1,15 → 1,14).",
   "maailma.upgrades.kosminen_karsivallisyys.name": "Kosmiskt tålamod",

--- a/src/tests/gameStoreMaailma.test.ts
+++ b/src/tests/gameStoreMaailma.test.ts
@@ -106,28 +106,6 @@ describe('Maailma upgrades via store actions', () => {
     expect(useGameStore.getState().modifiers.permanent.globalMultPerBuilding).toBeCloseTo(0.001, 6);
   });
 
-  it('allows early tier unlocks to bypass building requirements', () => {
-    useGameStore.setState((state) => ({
-      ...state,
-      population: 100000,
-      tierLevel: 1,
-      buildings: {},
-      maailma: { ...state.maailma, tuhka: '100' },
-    }));
-    useGameStore.getState().recompute();
-
-    useGameStore.getState().purchaseBuilding('ensiapu');
-    const intermediate = useGameStore.getState();
-    expect(intermediate.buildings.ensiapu).toBeUndefined();
-    expect(intermediate.population).toBeCloseTo(100000, 6);
-
-    expect(useGameStore.getState().purchaseMaailmaUpgrade('maailmankivi')).toBe(true);
-    useGameStore.getState().purchaseBuilding('ensiapu');
-    const after = useGameStore.getState();
-    expect(after.buildings.ensiapu).toBe(1);
-    expect(after.population).toBeCloseTo(90000, 6);
-  });
-
   it('scales offline gains with the permanent multiplier', () => {
     useGameStore.setState((state) => ({
       ...state,

--- a/src/tests/maailmaMigrations.test.ts
+++ b/src/tests/maailmaMigrations.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { __testMigrateRemovedMaailmaPurchases } from '../app/store';
+
+describe('maailma migration helpers', () => {
+  it('refunds removed Maailmankivi purchases and drops them from history', () => {
+    const legacy = {
+      tuhka: '10',
+      purchases: ['maailmankivi', 'tuhkan_viisaus', 'maailmankivi'],
+      totalTuhkaEarned: '0',
+      totalResets: 0,
+      era: 0,
+    };
+
+    const migrated = __testMigrateRemovedMaailmaPurchases(legacy);
+
+    expect(migrated).not.toBe(legacy);
+    expect(migrated.tuhka).toBe('130');
+    expect(migrated.purchases).toEqual(['tuhkan_viisaus']);
+    expect(legacy.purchases).toEqual(['maailmankivi', 'tuhkan_viisaus', 'maailmankivi']);
+  });
+
+  it('handles invalid Tuhka strings by treating them as zero before refunding', () => {
+    const legacy = {
+      tuhka: 'not-a-number',
+      purchases: ['maailmankivi'],
+      totalTuhkaEarned: '0',
+      totalResets: 0,
+      era: 0,
+    };
+
+    const migrated = __testMigrateRemovedMaailmaPurchases(legacy);
+
+    expect(migrated.tuhka).toBe('60');
+    expect(migrated.purchases).toEqual([]);
+  });
+
+  it('returns the original reference when no removed purchases are present', () => {
+    const current = {
+      tuhka: '42',
+      purchases: ['tuhkan_viisaus'],
+      totalTuhkaEarned: '100',
+      totalResets: 1,
+      era: 0,
+    };
+
+    const migrated = __testMigrateRemovedMaailmaPurchases(current);
+
+    expect(migrated).toBe(current);
+  });
+});

--- a/src/tests/permanentBonuses.test.ts
+++ b/src/tests/permanentBonuses.test.ts
@@ -9,7 +9,6 @@ describe('applyPermanentBonuses', () => {
           tuhkan_viisaus: { id: 'tuhkan_viisaus', level: 2 },
           ikuiset_hiillokset: { id: 'ikuiset_hiillokset', level: 3 },
           feeniks_sauna: { id: 'feeniks_sauna', level: 1 },
-          maailmankivi: { id: 'maailmankivi', level: 1 },
           tyhjyys_tehokkuus: { id: 'tyhjyys_tehokkuus', level: 10 },
           kosminen_karsivallisyys: { id: 'kosminen_karsivallisyys', level: 2 },
           tuhkan_infuusio: { id: 'tuhkan_infuusio', level: 3 },
@@ -26,7 +25,7 @@ describe('applyPermanentBonuses', () => {
     expect(bonuses.techMultiplierBonusAdd).toBeCloseTo(1.0, 6);
     expect(bonuses.baseProdMult).toBeCloseTo(1.5 ** 3, 6);
     expect(bonuses.saunaPrestigeBaseMultiplierMin).toBeCloseTo(10);
-    expect(bonuses.tierUnlockOffset).toBe(-1);
+    expect(bonuses.tierUnlockOffset).toBe(0);
     expect(bonuses.buildingCostMultiplier.delta).toBeCloseTo(-0.05, 6);
     expect(bonuses.buildingCostMultiplier.floor).toBeCloseTo(1.1, 6);
     expect(bonuses.offlineProdMult).toBeCloseTo(1 + 0.5 * 2, 6);
@@ -34,8 +33,8 @@ describe('applyPermanentBonuses', () => {
     expect(bonuses.perTierGlobalCpsAdd['7']).toBeCloseTo(1.5, 6);
     expect(bonuses.keepTechOnSaunaReset).toBe(true);
     expect(bonuses.globalCpsAddPerTuhkaSpent).toBeCloseTo(0.1 * 4, 10);
-    expect(bonuses.totalTuhkaSpent).toBe(668);
-    expect(bonuses.globalCpsAddFromTuhkaSpent).toBeCloseTo(0.1 * 4 * 668, 6);
+    expect(bonuses.totalTuhkaSpent).toBe(608);
+    expect(bonuses.globalCpsAddFromTuhkaSpent).toBeCloseTo(0.1 * 4 * 608, 6);
     expect(bonuses.globalMultPerBuilding).toBeCloseTo(0, 6);
   });
 


### PR DESCRIPTION
## Summary
- remove the Maailmankivi Maailma shop item and its translations
- add a migration that refunds Maailmankivi purchases and cover it with unit tests
- update existing tests and changelog to reflect the new catalog

## Testing
- npm run lint
- npm run test
- npm run check:i18n

------
https://chatgpt.com/codex/tasks/task_e_68d500bae8f483288f984c7ca42efeb7